### PR TITLE
feat: 메인화면 api 로직 구현

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,14 @@
+# API 문서
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 3
+
+== GitHub 주소
+
+* link:https://github.com/dankookie-4983/4983-server[GitHub 주소]
+
+== User 문서
+
+* link:usedBook.html[UsedBook 문서]

--- a/src/docs/asciidoc/usedBook.adoc
+++ b/src/docs/asciidoc/usedBook.adoc
@@ -1,0 +1,107 @@
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+
+== 메인 문서
+
+link:index.html[메인 문서]
+
+== UsedBook 메인페이지 관련 문서
+
+=== 조건없는 책 리스트 가져오기 (판매중, 거래중, 판매완료 순으로 보이고 각각 날짜에 따라 최신순으로 정렬)
+
+==== Request
+
+include::{snippets}/used-book-list/getUsedBookList/success/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/used-book-list/getUsedBookList/success/http-response.adoc[]
+include::{snippets}/used-book-list/getUsedBookList/success/response-fields.adoc[]
+
+
+=== 단과대 학과에 따라 서적 리스트 가져오기
+
+==== Request
+
+include::{snippets}/used-book-list/getUsedBookListWithCollegeAndDepartment/success/http-request.adoc[]
+include::{snippets}/used-book-list/getUsedBookListWithCollegeAndDepartment/success/query-parameters.adoc[]
+
+===== QueryParameter 예시
+api?college=ENGINEERING,EDUCATION&department=COMPUTER,SOFTWARE,KOREAN
+
+==== Response
+
+include::{snippets}/used-book-list/getUsedBookListWithCollegeAndDepartment/success/http-response.adoc[]
+include::{snippets}/used-book-list/getUsedBookListWithCollegeAndDepartment/success/response-fields.adoc[]
+
+
+===== College Enum (앞의 영어만 보면됨)
+    BUSINESS_AND_ECONOMICS("경영경제대학" ),
+    SW_CONVERGENCE("SW융합대학"),
+    SOCIAL_SCIENCES("사회과학대학"),
+    LITERAL_ARTS("문과대학"),
+    LAW("법과대학"),
+    ENGINEERING("공과대학"),
+    EDUCATION("사범대학"),
+    MUSIC_AND_ARTS("음악예술대학");
+
+===== Department Enum (앞에 영어만 보면됨)
+    BUSINESS("경영학과", BUSINESS_AND_ECONOMICS),
+    ECONOMICS("경제학과", BUSINESS_AND_ECONOMICS),
+    INTERNATIONAL_BUSINESS("국제경영학전공", BUSINESS_AND_ECONOMICS),
+    TRADE("무역학과", BUSINESS_AND_ECONOMICS),
+    INDUSTRIAL_BUSINESS("산업경영학과", BUSINESS_AND_ECONOMICS),
+    ACCOUNTING("회계학과", BUSINESS_AND_ECONOMICS),
+
+    POLITICAL("정치외교학과", SOCIAL_SCIENCES),
+    PUBLIC_ADMINISTRATION("행정학과", SOCIAL_SCIENCES),
+    URBAN_PLANNING("도시계획부동산학부", SOCIAL_SCIENCES),
+    MEDIA_COMMUNICATION("미디어커뮤니케이션학부", SOCIAL_SCIENCES),
+    CONSULTING("상담학과", SOCIAL_SCIENCES),
+
+    DEPARTMENT_OF_LAW("법학과", LAW),
+
+    KOREAN("국어국문과", LITERAL_ARTS),
+    HISTORY("사학과", LITERAL_ARTS),
+    PHILOSOPHY("철학과", LITERAL_ARTS),
+    AMERICAN_HUMANITY("영미인문학과", LITERAL_ARTS),
+
+    ELECTRICAL("전자전기공학전공", ENGINEERING),
+    POLYMER("고분자공학전공", ENGINEERING),
+    FUSION_SEMICONDUCTOR("융합반도체공학전공", ENGINEERING),
+    FIBER("파이버융합소재공학전공", ENGINEERING),
+    CHEMICAL("화학공학과", ENGINEERING),
+    ARCHITECTURE_ENGINEER("건축공학전공", ENGINEERING),
+    ARCHITECTURE("건축학전공", ENGINEERING),
+
+    SOFTWARE("소프트웨어학과", SW_CONVERGENCE),
+    COMPUTER("컴퓨터공학과", SW_CONVERGENCE),
+    MOBILE_SYSTEM("모바일시스템공학과", SW_CONVERGENCE),
+    STATISTICS("정보통계학과", SW_CONVERGENCE),
+    SECURITY("산업보안학과", SW_CONVERGENCE),
+
+    MATH("수학교육과", EDUCATION),
+    SCIENCE("과학교육과", EDUCATION),
+    ATHLETIC("체육교육과", EDUCATION),
+    CHINESE("한문교육과", EDUCATION),
+    SPECIAL("특수교육과", EDUCATION),
+
+    MOVIE("영화전공", MUSIC_AND_ARTS),
+    THEATER("연극전공", MUSIC_AND_ARTS),
+    MUSICAL("뮤지컬전공", MUSIC_AND_ARTS),
+    CERAMICS("도예과", MUSIC_AND_ARTS),
+    COMMUNICATION_DESIGN("커뮤니케이션디자인전공", MUSIC_AND_ARTS),
+    INDUSTRIAL_DESIGN("패션산업디자인전공", MUSIC_AND_ARTS),
+    DANCING("무용과", MUSIC_AND_ARTS),
+    PIANO("피아노전공", MUSIC_AND_ARTS),
+    VOCAL("성악전공", MUSIC_AND_ARTS),
+    ORCHESTRA("관현악전공", MUSIC_AND_ARTS),
+    COMPOSITION("작곡전공", MUSIC_AND_ARTS),
+    GUGAK("국악전공", MUSIC_AND_ARTS);
+
+
+
+

--- a/src/main/java/team/dankookie/server4983/book/constant/BookStatus.java
+++ b/src/main/java/team/dankookie/server4983/book/constant/BookStatus.java
@@ -1,0 +1,16 @@
+package team.dankookie.server4983.book.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum BookStatus {
+
+    SALE("판매중"),
+    TRADE("거래중"),
+    SOLD("판매완료");
+
+    private final String status;
+
+}

--- a/src/main/java/team/dankookie/server4983/book/controller/UsedBookListController.java
+++ b/src/main/java/team/dankookie/server4983/book/controller/UsedBookListController.java
@@ -21,17 +21,17 @@ public class UsedBookListController {
     private final UsedBookListService usedBookListService;
 
     @GetMapping
-    public ResponseEntity<List<UsedBookListResponse>> getUsedBookList(@RequestParam boolean canBuy) {
-        return ResponseEntity.ok(usedBookListService.getUsedBookList(canBuy));
+    public ResponseEntity<List<UsedBookListResponse>> getUsedBookList(@RequestParam boolean canBuyElseAll) {
+        return ResponseEntity.ok(usedBookListService.getUsedBookList(canBuyElseAll));
     }
 
     @GetMapping("/college-and-department")
     public ResponseEntity<List<UsedBookListResponse>> getUsedBookListByCollegeAndDepartment(
-            @RequestParam boolean canBuy,
+            @RequestParam boolean canBuyElseAll,
             @RequestParam List<College> college,
             @RequestParam List<Department> department
     ) {
-        return ResponseEntity.ok(usedBookListService.getUsedBookList(college, department, canBuy));
+        return ResponseEntity.ok(usedBookListService.getUsedBookList(college, department, canBuyElseAll));
     }
 
 

--- a/src/main/java/team/dankookie/server4983/book/controller/UsedBookListController.java
+++ b/src/main/java/team/dankookie/server4983/book/controller/UsedBookListController.java
@@ -1,0 +1,38 @@
+package team.dankookie.server4983.book.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import team.dankookie.server4983.book.constant.College;
+import team.dankookie.server4983.book.constant.Department;
+import team.dankookie.server4983.book.dto.UsedBookListResponse;
+import team.dankookie.server4983.book.service.UsedBookListService;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/used-book-list")
+public class UsedBookListController {
+
+    private final UsedBookListService usedBookListService;
+
+    @GetMapping
+    public ResponseEntity<List<UsedBookListResponse>> getUsedBookList(@RequestParam boolean canBuy) {
+        return ResponseEntity.ok(usedBookListService.getUsedBookList(canBuy));
+    }
+
+    @GetMapping("/college-and-department")
+    public ResponseEntity<List<UsedBookListResponse>> getUsedBookListByCollegeAndDepartment(
+            @RequestParam boolean canBuy,
+            @RequestParam List<College> college,
+            @RequestParam List<Department> department
+    ) {
+        return ResponseEntity.ok(usedBookListService.getUsedBookList(college, department, canBuy));
+    }
+
+
+}

--- a/src/main/java/team/dankookie/server4983/book/domain/BookImage.java
+++ b/src/main/java/team/dankookie/server4983/book/domain/BookImage.java
@@ -2,6 +2,7 @@ package team.dankookie.server4983.book.domain;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -16,7 +17,12 @@ public class BookImage {
     private String imageUrl;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "used_book_id")
     private UsedBook usedBook;
 
-
+    @Builder
+    public BookImage(String imageUrl, UsedBook usedBook) {
+        this.imageUrl = imageUrl;
+        this.usedBook = usedBook;
+    }
 }

--- a/src/main/java/team/dankookie/server4983/book/domain/UsedBook.java
+++ b/src/main/java/team/dankookie/server4983/book/domain/UsedBook.java
@@ -3,8 +3,10 @@ package team.dankookie.server4983.book.domain;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import team.dankookie.server4983.book.constant.BookStatus;
 import team.dankookie.server4983.book.constant.College;
 import team.dankookie.server4983.book.constant.Department;
 import team.dankookie.server4983.common.domain.BaseEntity;
@@ -38,6 +40,9 @@ public class UsedBook extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Department department;
 
+    @Enumerated(EnumType.STRING)
+    private BookStatus bookStatus;
+
     @Column(columnDefinition = "boolean default false")
     private Boolean isUnderlinedOrWrite;
 
@@ -47,14 +52,18 @@ public class UsedBook extends BaseEntity {
     @Column(columnDefinition = "boolean default false")
     private Boolean isCoverDamaged;
 
-    @Column(columnDefinition = "boolean default true")
-    private Boolean onSailed;
-
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     private Member buyerMember;
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Member sellerMember;
 
-
+    @Builder
+    public UsedBook(String name, Integer price, LocalDate tradeAvailableDate, BookStatus bookStatus, Member buyerMember) {
+        this.name = name;
+        this.price = price;
+        this.tradeAvailableDate = tradeAvailableDate;
+        this.bookStatus = bookStatus;
+        this.buyerMember = buyerMember;
+    }
 }

--- a/src/main/java/team/dankookie/server4983/book/domain/UsedBook.java
+++ b/src/main/java/team/dankookie/server4983/book/domain/UsedBook.java
@@ -59,11 +59,13 @@ public class UsedBook extends BaseEntity {
     private Member sellerMember;
 
     @Builder
-    public UsedBook(String name, Integer price, LocalDate tradeAvailableDate, BookStatus bookStatus, Member buyerMember) {
+    public UsedBook(String name, Integer price, LocalDate tradeAvailableDate, BookStatus bookStatus, Member buyerMember, Department department, College college) {
         this.name = name;
         this.price = price;
         this.tradeAvailableDate = tradeAvailableDate;
         this.bookStatus = bookStatus;
         this.buyerMember = buyerMember;
+        this.department = department;
+        this.college = college;
     }
 }

--- a/src/main/java/team/dankookie/server4983/book/dto/UsedBookListResponse.java
+++ b/src/main/java/team/dankookie/server4983/book/dto/UsedBookListResponse.java
@@ -1,0 +1,22 @@
+package team.dankookie.server4983.book.dto;
+
+import lombok.Builder;
+import team.dankookie.server4983.book.constant.BookStatus;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record UsedBookListResponse (
+        String imageUrl,
+        BookStatus bookStatus,
+        String name,
+        LocalDate tradeAvailableDate,
+        LocalDateTime createdAt,
+        Integer price
+){
+
+    @Builder
+    public UsedBookListResponse {
+    }
+}
+

--- a/src/main/java/team/dankookie/server4983/book/repository/bookImage/BookImageRepository.java
+++ b/src/main/java/team/dankookie/server4983/book/repository/bookImage/BookImageRepository.java
@@ -1,0 +1,8 @@
+package team.dankookie.server4983.book.repository.bookImage;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team.dankookie.server4983.book.domain.BookImage;
+import team.dankookie.server4983.book.domain.UsedBook;
+
+public interface BookImageRepository extends JpaRepository<BookImage, Long> , BookImageRepositoryCustom{
+}

--- a/src/main/java/team/dankookie/server4983/book/repository/bookImage/BookImageRepositoryCustom.java
+++ b/src/main/java/team/dankookie/server4983/book/repository/bookImage/BookImageRepositoryCustom.java
@@ -1,0 +1,5 @@
+package team.dankookie.server4983.book.repository.bookImage;
+
+public interface BookImageRepositoryCustom {
+    String getBookImageUrlByUsedBookId(Long usedBookId);
+}

--- a/src/main/java/team/dankookie/server4983/book/repository/bookImage/BookImageRepositoryImpl.java
+++ b/src/main/java/team/dankookie/server4983/book/repository/bookImage/BookImageRepositoryImpl.java
@@ -1,0 +1,21 @@
+package team.dankookie.server4983.book.repository.bookImage;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import static team.dankookie.server4983.book.domain.QBookImage.bookImage;
+
+@RequiredArgsConstructor
+public class BookImageRepositoryImpl implements BookImageRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public String getBookImageUrlByUsedBookId(Long usedBookId) {
+        return queryFactory.select(bookImage.imageUrl)
+                .from(bookImage)
+                .where(bookImage.usedBook.id.eq(usedBookId))
+                .orderBy(bookImage.id.desc())
+                .fetchOne();
+    }
+}

--- a/src/main/java/team/dankookie/server4983/book/repository/usedBook/UsedBookRepository.java
+++ b/src/main/java/team/dankookie/server4983/book/repository/usedBook/UsedBookRepository.java
@@ -1,0 +1,7 @@
+package team.dankookie.server4983.book.repository.usedBook;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team.dankookie.server4983.book.domain.UsedBook;
+
+public interface UsedBookRepository extends JpaRepository<UsedBook, Long>, UsedBookRepositoryCustom {
+}

--- a/src/main/java/team/dankookie/server4983/book/repository/usedBook/UsedBookRepositoryCustom.java
+++ b/src/main/java/team/dankookie/server4983/book/repository/usedBook/UsedBookRepositoryCustom.java
@@ -1,0 +1,14 @@
+package team.dankookie.server4983.book.repository.usedBook;
+
+import team.dankookie.server4983.book.constant.College;
+import team.dankookie.server4983.book.constant.Department;
+import team.dankookie.server4983.book.domain.UsedBook;
+
+import java.util.List;
+
+public interface UsedBookRepositoryCustom {
+
+    List<UsedBook> getUsedBookList(boolean canBuy);
+
+    List<UsedBook> getUsedBookListInCollegeAndDepartment(List<College> college, List<Department> department, boolean canBuy);
+}

--- a/src/main/java/team/dankookie/server4983/book/repository/usedBook/UsedBookRepositoryCustom.java
+++ b/src/main/java/team/dankookie/server4983/book/repository/usedBook/UsedBookRepositoryCustom.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public interface UsedBookRepositoryCustom {
 
-    List<UsedBook> getUsedBookList(boolean canBuy);
+    List<UsedBook> getUsedBookList(boolean canBuyElseAll);
 
-    List<UsedBook> getUsedBookListInCollegeAndDepartment(List<College> college, List<Department> department, boolean canBuy);
+    List<UsedBook> getUsedBookListInCollegeAndDepartment(List<College> college, List<Department> department, boolean canBuyElseAll);
 }

--- a/src/main/java/team/dankookie/server4983/book/repository/usedBook/UsedBookRepositoryImpl.java
+++ b/src/main/java/team/dankookie/server4983/book/repository/usedBook/UsedBookRepositoryImpl.java
@@ -19,28 +19,21 @@ public class UsedBookRepositoryImpl implements UsedBookRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<UsedBook> getUsedBookList(boolean canBuy) {
+    public List<UsedBook> getUsedBookList(boolean canBuyElseAll) {
         JPAQuery<UsedBook> query = queryFactory.selectFrom(usedBook);
-        return getUsedBooksCanBuyOrNot(canBuy, query);
+        return getUsedBooksCanBuyElseAll(canBuyElseAll, query);
     }
 
     @Override
-    public List<UsedBook> getUsedBookListInCollegeAndDepartment(List<College> college, List<Department> department, boolean canBuy) {
+    public List<UsedBook> getUsedBookListInCollegeAndDepartment(List<College> college, List<Department> department, boolean canBuyElseAll) {
         JPAQuery<UsedBook> query = queryFactory.selectFrom(usedBook);
 
-        if (!college.isEmpty() && !department.isEmpty()) {
-            query.where(usedBook.college.in(college).and(usedBook.department.in(department)));
-        } else if (!college.isEmpty()) {
-            query.where(usedBook.college.in(college));
-        } else if (!department.isEmpty()) {
-            query.where(usedBook.department.in(department));
-        }
-
-        return getUsedBooksCanBuyOrNot(canBuy, query);
+        query.where(usedBook.college.in(college).or(usedBook.department.in(department)));
+        return getUsedBooksCanBuyElseAll(canBuyElseAll, query);
     }
 
-    private List<UsedBook> getUsedBooksCanBuyOrNot(boolean canBuy, JPAQuery<UsedBook> query) {
-        if (canBuy) {
+    private List<UsedBook> getUsedBooksCanBuyElseAll(boolean canBuyElseAll, JPAQuery<UsedBook> query) {
+        if (canBuyElseAll) {
             return query
                     .where(usedBook.bookStatus.eq(BookStatus.SALE))
                     .orderBy(usedBook.createdAt.desc()).fetch();

--- a/src/main/java/team/dankookie/server4983/book/repository/usedBook/UsedBookRepositoryImpl.java
+++ b/src/main/java/team/dankookie/server4983/book/repository/usedBook/UsedBookRepositoryImpl.java
@@ -1,0 +1,61 @@
+package team.dankookie.server4983.book.repository.usedBook;
+
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import team.dankookie.server4983.book.constant.BookStatus;
+import team.dankookie.server4983.book.constant.College;
+import team.dankookie.server4983.book.constant.Department;
+import team.dankookie.server4983.book.domain.UsedBook;
+
+import java.util.List;
+
+import static team.dankookie.server4983.book.domain.QUsedBook.usedBook;
+
+@RequiredArgsConstructor
+public class UsedBookRepositoryImpl implements UsedBookRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<UsedBook> getUsedBookList(boolean canBuy) {
+        JPAQuery<UsedBook> query = queryFactory.selectFrom(usedBook);
+        return getUsedBooksCanBuyOrNot(canBuy, query);
+    }
+
+    @Override
+    public List<UsedBook> getUsedBookListInCollegeAndDepartment(List<College> college, List<Department> department, boolean canBuy) {
+        JPAQuery<UsedBook> query = queryFactory.selectFrom(usedBook);
+
+        if (!college.isEmpty() && !department.isEmpty()) {
+            query.where(usedBook.college.in(college).and(usedBook.department.in(department)));
+        } else if (!college.isEmpty()) {
+            query.where(usedBook.college.in(college));
+        } else if (!department.isEmpty()) {
+            query.where(usedBook.department.in(department));
+        }
+
+        return getUsedBooksCanBuyOrNot(canBuy, query);
+    }
+
+    private List<UsedBook> getUsedBooksCanBuyOrNot(boolean canBuy, JPAQuery<UsedBook> query) {
+        if (canBuy) {
+            return query
+                    .where(usedBook.bookStatus.eq(BookStatus.SALE))
+                    .orderBy(usedBook.createdAt.desc()).fetch();
+        }else {
+            return query
+                    .orderBy(
+                            new CaseBuilder()
+                                    .when(usedBook.bookStatus.eq(BookStatus.SALE)).then(1)
+                                    .when(usedBook.bookStatus.eq(BookStatus.TRADE)).then(2)
+                                    .when(usedBook.bookStatus.eq(BookStatus.SOLD)).then(3)
+                                    .otherwise(4)
+                                    .asc(),
+                            usedBook.createdAt.desc()
+                    )
+                    .fetch();
+        }
+    }
+}

--- a/src/main/java/team/dankookie/server4983/book/service/UsedBookListService.java
+++ b/src/main/java/team/dankookie/server4983/book/service/UsedBookListService.java
@@ -1,0 +1,55 @@
+package team.dankookie.server4983.book.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import team.dankookie.server4983.book.constant.College;
+import team.dankookie.server4983.book.constant.Department;
+import team.dankookie.server4983.book.domain.UsedBook;
+import team.dankookie.server4983.book.dto.UsedBookListResponse;
+import team.dankookie.server4983.book.repository.bookImage.BookImageRepository;
+import team.dankookie.server4983.book.repository.usedBook.UsedBookRepository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class UsedBookListService {
+
+    private final UsedBookRepository usedBookRepository;
+    private final BookImageRepository bookImageRepository;
+
+    public List<UsedBookListResponse> getUsedBookList(boolean canBuy) {
+
+        List<UsedBookListResponse> responseList = new ArrayList<>();
+
+        List<UsedBook> usedBookList = usedBookRepository.getUsedBookList(canBuy);
+
+        return getUsedBookListResponses(responseList, usedBookList);
+    }
+
+    public List<UsedBookListResponse> getUsedBookList(List<College> college, List<Department> department, boolean canBuy) {
+        List<UsedBookListResponse> responseList = new ArrayList<>();
+
+        List<UsedBook> usedBookList = usedBookRepository.getUsedBookListInCollegeAndDepartment(college, department, canBuy);
+
+        return getUsedBookListResponses(responseList, usedBookList);
+    }
+
+    private List<UsedBookListResponse> getUsedBookListResponses(List<UsedBookListResponse> responseList, List<UsedBook> usedBookList) {
+        for (UsedBook usedBook : usedBookList) {
+            String firstImageUrl = bookImageRepository.getBookImageUrlByUsedBookId(usedBook.getId());
+            UsedBookListResponse usedBookListResponse = UsedBookListResponse.builder()
+                    .imageUrl(firstImageUrl)
+                    .bookStatus(usedBook.getBookStatus())
+                    .name(usedBook.getName())
+                    .tradeAvailableDate(usedBook.getTradeAvailableDate())
+                    .createdAt(usedBook.getCreatedAt())
+                    .price(usedBook.getPrice())
+                    .build();
+            responseList.add(usedBookListResponse);
+        }
+
+        return responseList;
+    }
+}

--- a/src/main/java/team/dankookie/server4983/book/service/UsedBookListService.java
+++ b/src/main/java/team/dankookie/server4983/book/service/UsedBookListService.java
@@ -19,19 +19,19 @@ public class UsedBookListService {
     private final UsedBookRepository usedBookRepository;
     private final BookImageRepository bookImageRepository;
 
-    public List<UsedBookListResponse> getUsedBookList(boolean canBuy) {
+    public List<UsedBookListResponse> getUsedBookList(boolean canBuyElseAll) {
 
         List<UsedBookListResponse> responseList = new ArrayList<>();
 
-        List<UsedBook> usedBookList = usedBookRepository.getUsedBookList(canBuy);
+        List<UsedBook> usedBookList = usedBookRepository.getUsedBookList(canBuyElseAll);
 
         return getUsedBookListResponses(responseList, usedBookList);
     }
 
-    public List<UsedBookListResponse> getUsedBookList(List<College> college, List<Department> department, boolean canBuy) {
+    public List<UsedBookListResponse> getUsedBookList(List<College> college, List<Department> department, boolean canBuyElseAll) {
         List<UsedBookListResponse> responseList = new ArrayList<>();
 
-        List<UsedBook> usedBookList = usedBookRepository.getUsedBookListInCollegeAndDepartment(college, department, canBuy);
+        List<UsedBook> usedBookList = usedBookRepository.getUsedBookListInCollegeAndDepartment(college, department, canBuyElseAll);
 
         return getUsedBookListResponses(responseList, usedBookList);
     }

--- a/src/main/java/team/dankookie/server4983/common/domain/BaseEntity.java
+++ b/src/main/java/team/dankookie/server4983/common/domain/BaseEntity.java
@@ -15,11 +15,10 @@ import java.time.LocalDateTime;
 @Getter
 public abstract class BaseEntity {
 
-    @Column(nullable = false, updatable = false)
+    @Column(updatable = false)
     @CreatedDate
     private LocalDateTime createdAt;
 
-    @Column(nullable = false)
     @LastModifiedDate
     private LocalDateTime updatedAt;
 

--- a/src/main/java/team/dankookie/server4983/member/domain/Member.java
+++ b/src/main/java/team/dankookie/server4983/member/domain/Member.java
@@ -6,7 +6,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.DynamicInsert;
+import team.dankookie.server4983.book.constant.Department;
 import team.dankookie.server4983.common.domain.BaseEntity;
 import team.dankookie.server4983.member.constant.AccountBank;
 
@@ -22,7 +22,8 @@ public class Member extends BaseEntity {
     private String studentId;
 
     @NotNull
-    private String department;
+    @Enumerated(EnumType.STRING)
+    private Department department;
 
     @NotNull
     private Integer yearOfAdmission;
@@ -54,7 +55,7 @@ public class Member extends BaseEntity {
     private Boolean marketingAgree;
 
     @Builder
-    public Member(String studentId, String department, Integer yearOfAdmission, String nickname, String password, String phoneNumber, String accountHolder, AccountBank accountBank, String accountNumber) {
+    public Member(String studentId, Department department, Integer yearOfAdmission, String nickname, String password, String phoneNumber, String accountHolder, AccountBank accountBank, String accountNumber) {
         this.studentId = studentId;
         this.department = department;
         this.yearOfAdmission = yearOfAdmission;

--- a/src/main/java/team/dankookie/server4983/member/domain/Member.java
+++ b/src/main/java/team/dankookie/server4983/member/domain/Member.java
@@ -3,13 +3,13 @@ package team.dankookie.server4983.member.domain;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicInsert;
 import team.dankookie.server4983.common.domain.BaseEntity;
 import team.dankookie.server4983.member.constant.AccountBank;
 
-@DynamicInsert
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
@@ -52,6 +52,19 @@ public class Member extends BaseEntity {
 
     @Column(columnDefinition = "boolean default false")
     private Boolean marketingAgree;
+
+    @Builder
+    public Member(String studentId, String department, Integer yearOfAdmission, String nickname, String password, String phoneNumber, String accountHolder, AccountBank accountBank, String accountNumber) {
+        this.studentId = studentId;
+        this.department = department;
+        this.yearOfAdmission = yearOfAdmission;
+        this.nickname = nickname;
+        this.password = password;
+        this.phoneNumber = phoneNumber;
+        this.accountHolder = accountHolder;
+        this.accountBank = accountBank;
+        this.accountNumber = accountNumber;
+    }
 
 
 

--- a/src/main/java/team/dankookie/server4983/member/repository/MemberRepository.java
+++ b/src/main/java/team/dankookie/server4983/member/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package team.dankookie.server4983.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team.dankookie.server4983.member.domain.Member;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -1,0 +1,495 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 2.0.18">
+<title>API 문서</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
+<style>
+/*! Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
+/* Uncomment the following line when using as a custom stylesheet */
+/* @import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700"; */
+html{font-family:sans-serif;-webkit-text-size-adjust:100%}
+a{background:none}
+a:focus{outline:thin dotted}
+a:active,a:hover{outline:0}
+h1{font-size:2em;margin:.67em 0}
+b,strong{font-weight:bold}
+abbr{font-size:.9em}
+abbr[title]{cursor:help;border-bottom:1px dotted #dddddf;text-decoration:none}
+dfn{font-style:italic}
+hr{height:0}
+mark{background:#ff0;color:#000}
+code,kbd,pre,samp{font-family:monospace;font-size:1em}
+pre{white-space:pre-wrap}
+q{quotes:"\201C" "\201D" "\2018" "\2019"}
+small{font-size:80%}
+sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
+sup{top:-.5em}
+sub{bottom:-.25em}
+img{border:0}
+svg:not(:root){overflow:hidden}
+figure{margin:0}
+audio,video{display:inline-block}
+audio:not([controls]){display:none;height:0}
+fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
+legend{border:0;padding:0}
+button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
+button,input{line-height:normal}
+button,select{text-transform:none}
+button,html input[type=button],input[type=reset],input[type=submit]{-webkit-appearance:button;cursor:pointer}
+button[disabled],html input[disabled]{cursor:default}
+input[type=checkbox],input[type=radio]{padding:0}
+button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
+textarea{overflow:auto;vertical-align:top}
+table{border-collapse:collapse;border-spacing:0}
+*,::before,::after{box-sizing:border-box}
+html,body{font-size:100%}
+body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;line-height:1;position:relative;cursor:auto;-moz-tab-size:4;-o-tab-size:4;tab-size:4;word-wrap:anywhere;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
+a:hover{cursor:pointer}
+img,object,embed{max-width:100%;height:auto}
+object,embed{height:100%}
+img{-ms-interpolation-mode:bicubic}
+.left{float:left!important}
+.right{float:right!important}
+.text-left{text-align:left!important}
+.text-right{text-align:right!important}
+.text-center{text-align:center!important}
+.text-justify{text-align:justify!important}
+.hide{display:none}
+img,object,svg{display:inline-block;vertical-align:middle}
+textarea{height:auto;min-height:50px}
+select{width:100%}
+.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
+div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0}
+a{color:#2156a5;text-decoration:underline;line-height:inherit}
+a:hover,a:focus{color:#1d4b8f}
+a img{border:0}
+p{line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
+p aside{font-size:.875em;line-height:1.35;font-style:italic}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
+h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
+h1{font-size:2.125em}
+h2{font-size:1.6875em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
+h4,h5{font-size:1.125em}
+h6{font-size:1em}
+hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em}
+em,i{font-style:italic;line-height:inherit}
+strong,b{font-weight:bold;line-height:inherit}
+small{font-size:60%;line-height:inherit}
+code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
+ul,ol,dl{line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
+ul,ol{margin-left:1.5em}
+ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0}
+ul.circle{list-style-type:circle}
+ul.disc{list-style-type:disc}
+ul.square{list-style-type:square}
+ul.circle ul:not([class]),ul.disc ul:not([class]),ul.square ul:not([class]){list-style:inherit}
+ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
+dl dt{margin-bottom:.3125em;font-weight:bold}
+dl dd{margin-bottom:1.25em}
+blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
+blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
+@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
+h1{font-size:2.75em}
+h2{font-size:2.3125em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
+h4{font-size:1.4375em}}
+table{background:#fff;margin-bottom:1.25em;border:1px solid #dedede;word-wrap:normal}
+table thead,table tfoot{background:#f7f8f7}
+table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
+table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
+table tr.even,table tr.alt{background:#f8f8f7}
+table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{line-height:1.6}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
+h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
+.center{margin-left:auto;margin-right:auto}
+.stretch{width:100%}
+.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
+.clearfix::after,.float-group::after{clear:both}
+:not(pre).nobreak{word-wrap:normal}
+:not(pre).nowrap{white-space:nowrap}
+:not(pre).pre-wrap{white-space:pre-wrap}
+:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed}
+pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
+pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
+pre>code{display:block}
+pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
+em em{font-style:normal}
+strong strong{font-weight:400}
+.keyseq{color:rgba(51,51,51,.8)}
+kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;border-radius:3px;box-shadow:0 1px 0 rgba(0,0,0,.2),inset 0 0 0 .1em #fff;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
+.keyseq kbd:first-child{margin-left:0}
+.keyseq kbd:last-child{margin-right:0}
+.menuseq,.menuref{color:#000}
+.menuseq b:not(.caret),.menuref{font-weight:inherit}
+.menuseq{word-spacing:-.02em}
+.menuseq b.caret{font-size:1.25em;line-height:.8}
+.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
+b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
+b.button::before{content:"[";padding:0 3px 0 2px}
+b.button::after{content:"]";padding:0 2px 0 3px}
+p a>code:hover{color:rgba(0,0,0,.9)}
+#header,#content,#footnotes,#footer{width:100%;margin:0 auto;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
+#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
+#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
+#content{margin-top:1.25em}
+#content::before{content:none}
+#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
+#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
+#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
+#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:flex;flex-flow:row wrap}
+#header .details span:first-child{margin-left:-.125em}
+#header .details span.email a{color:rgba(0,0,0,.85)}
+#header .details br{display:none}
+#header .details br+span::before{content:"\00a0\2013\00a0"}
+#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
+#header .details br+span#revremark::before{content:"\00a0|\00a0"}
+#header #revnumber{text-transform:capitalize}
+#header #revnumber::after{content:"\00a0"}
+#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #dddddf;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
+#toc{border-bottom:1px solid #e7e7e9;padding-bottom:.5em}
+#toc>ul{margin-left:.125em}
+#toc ul.sectlevel0>li>a{font-style:italic}
+#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
+#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
+#toc li{line-height:1.3334;margin-top:.3334em}
+#toc a{text-decoration:none}
+#toc a:active{text-decoration:underline}
+#toctitle{color:#7a2518;font-size:1.2em}
+@media screen and (min-width:768px){#toctitle{font-size:1.375em}
+body.toc2{padding-left:15em;padding-right:0}
+#toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
+#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
+#toc.toc2>ul{font-size:.9em;margin-bottom:0}
+#toc.toc2 ul ul{margin-left:0;padding-left:1em}
+#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
+body.toc2.toc-right{padding-left:0;padding-right:15em}
+body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9;left:auto;right:0}}
+@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
+#toc.toc2{width:20em}
+#toc.toc2 #toctitle{font-size:1.375em}
+#toc.toc2>ul{font-size:.95em}
+#toc.toc2 ul ul{padding-left:1.25em}
+body.toc2.toc-right{padding-left:0;padding-right:20em}}
+#content #toc{border:1px solid #e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;border-radius:4px}
+#content #toc>:first-child{margin-top:0}
+#content #toc>:last-child{margin-bottom:0}
+#footer{max-width:none;background:rgba(0,0,0,.8);padding:1.25em}
+#footer-text{color:hsla(0,0%,100%,.8);line-height:1.44}
+#content{margin-bottom:.625em}
+.sect1{padding-bottom:.625em}
+@media screen and (min-width:768px){#content{margin-bottom:1.25em}
+.sect1{padding-bottom:1.25em}}
+.sect1:last-child{padding-bottom:0}
+.sect1+.sect1{border-top:1px solid #e7e7e9}
+#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
+#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
+#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
+#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
+#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
+details,.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
+details{margin-left:1.25rem}
+details>summary{cursor:pointer;display:block;position:relative;line-height:1.6;margin-bottom:.625rem;outline:none;-webkit-tap-highlight-color:transparent}
+details>summary::-webkit-details-marker{display:none}
+details>summary::before{content:"";border:solid transparent;border-left:solid;border-width:.3em 0 .3em .5em;position:absolute;top:.5em;left:-1.25rem;transform:translateX(15%)}
+details[open]>summary::before{border:solid transparent;border-top:solid;border-width:.5em .3em 0;transform:translateY(15%)}
+details>summary::after{content:"";width:1.25rem;height:1em;position:absolute;top:.3em;left:-1.25rem}
+.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
+table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
+.paragraph.lead>p,#preamble>.sectionbody>[class=paragraph]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
+.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
+.admonitionblock>table td.icon{text-align:center;width:80px}
+.admonitionblock>table td.icon img{max-width:none}
+.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
+.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6);word-wrap:anywhere}
+.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
+.exampleblock>.content{border:1px solid #e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;border-radius:4px}
+.exampleblock>.content>:first-child{margin-top:0}
+.exampleblock>.content>:last-child{margin-bottom:0}
+.sidebarblock{border:1px solid #dbdbd6;margin-bottom:1.25em;padding:1.25em;background:#f3f3f2;border-radius:4px}
+.sidebarblock>:first-child{margin-top:0}
+.sidebarblock>:last-child{margin-bottom:0}
+.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
+.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
+.literalblock pre,.listingblock>.content>pre{border-radius:4px;overflow-x:auto;padding:1em;font-size:.8125em}
+@media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
+@media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
+.literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class=highlight],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
+.literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
+.listingblock>.content{position:relative}
+.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
+.listingblock:hover code[data-lang]::before{display:block}
+.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
+.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
+.listingblock pre.highlightjs{padding:0}
+.listingblock pre.highlightjs>code{padding:1em;border-radius:4px}
+.listingblock pre.prettyprint{border-width:0}
+.prettyprint{background:#f7f7f8}
+pre.prettyprint .linenums{line-height:1.45;margin-left:2em}
+pre.prettyprint li{background:none;list-style-type:inherit;padding-left:0}
+pre.prettyprint li code[data-lang]::before{opacity:1}
+pre.prettyprint li:not(:first-child) code[data-lang]::before{display:none}
+table.linenotable{border-collapse:separate;border:0;margin-bottom:0;background:none}
+table.linenotable td[class]{color:inherit;vertical-align:top;padding:0;line-height:inherit;white-space:normal}
+table.linenotable td.code{padding-left:.75em}
+table.linenotable td.linenos,pre.pygments .linenos{border-right:1px solid;opacity:.35;padding-right:.5em;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}
+pre.pygments span.linenos{display:inline-block;margin-right:.75em}
+.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
+.quoteblock:not(.excerpt)>.title{margin-left:-1.5em;margin-bottom:.75em}
+.quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
+.quoteblock blockquote{margin:0;padding:0;border:0}
+.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
+.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
+.quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
+.verseblock{margin:0 1em 1.25em}
+.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans-serif;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
+.verseblock pre strong{font-weight:400}
+.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
+.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
+.quoteblock .attribution br,.verseblock .attribution br{display:none}
+.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
+.quoteblock.abstract blockquote::before,.quoteblock.excerpt blockquote::before,.quoteblock .quoteblock blockquote::before{display:none}
+.quoteblock.abstract blockquote,.quoteblock.abstract p,.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{line-height:1.6;word-spacing:0}
+.quoteblock.abstract{margin:0 1em 1.25em;display:block}
+.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
+.quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
+.quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
+.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
+.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;font-size:.85rem;text-align:left;margin-right:0}
+p.tableblock:last-child{margin-bottom:0}
+td.tableblock>.content{margin-bottom:1.25em;word-wrap:anywhere}
+td.tableblock>.content>:last-child{margin-bottom:-1.25em}
+table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
+table.grid-all>*>tr>*{border-width:1px}
+table.grid-cols>*>tr>*{border-width:0 1px}
+table.grid-rows>*>tr>*{border-width:1px 0}
+table.frame-all{border-width:1px}
+table.frame-ends{border-width:1px 0}
+table.frame-sides{border-width:0 1px}
+table.frame-none>colgroup+*>:first-child>*,table.frame-sides>colgroup+*>:first-child>*{border-top-width:0}
+table.frame-none>:last-child>:last-child>*,table.frame-sides>:last-child>:last-child>*{border-bottom-width:0}
+table.frame-none>*>tr>:first-child,table.frame-ends>*>tr>:first-child{border-left-width:0}
+table.frame-none>*>tr>:last-child,table.frame-ends>*>tr>:last-child{border-right-width:0}
+table.stripes-all>*>tr,table.stripes-odd>*>tr:nth-of-type(odd),table.stripes-even>*>tr:nth-of-type(even),table.stripes-hover>*>tr:hover{background:#f8f8f7}
+th.halign-left,td.halign-left{text-align:left}
+th.halign-right,td.halign-right{text-align:right}
+th.halign-center,td.halign-center{text-align:center}
+th.valign-top,td.valign-top{vertical-align:top}
+th.valign-bottom,td.valign-bottom{vertical-align:bottom}
+th.valign-middle,td.valign-middle{vertical-align:middle}
+table thead th,table tfoot th{font-weight:bold}
+tbody tr th{background:#f7f8f7}
+tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
+p.tableblock>code:only-child{background:none;padding:0}
+p.tableblock{font-size:1em}
+ol{margin-left:1.75em}
+ul li ol{margin-left:1.5em}
+dl dd{margin-left:1.125em}
+dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
+li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
+ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
+ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
+ul.unstyled,ol.unstyled{margin-left:0}
+li>p:empty:only-child::before{content:"";display:inline-block}
+ul.checklist>li>p:first-child{margin-left:-1em}
+ul.checklist>li>p:first-child>.fa-square-o:first-child,ul.checklist>li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
+ul.checklist>li>p:first-child>input[type=checkbox]:first-child{margin-right:.25em}
+ul.inline{display:flex;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
+ul.inline>li{margin-left:1.25em}
+.unstyled dl dt{font-weight:400;font-style:normal}
+ol.arabic{list-style-type:decimal}
+ol.decimal{list-style-type:decimal-leading-zero}
+ol.loweralpha{list-style-type:lower-alpha}
+ol.upperalpha{list-style-type:upper-alpha}
+ol.lowerroman{list-style-type:lower-roman}
+ol.upperroman{list-style-type:upper-roman}
+ol.lowergreek{list-style-type:lower-greek}
+.hdlist>table,.colist>table{border:0;background:none}
+.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
+td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
+td.hdlist1{font-weight:bold;padding-bottom:1.25em}
+td.hdlist2{word-wrap:anywhere}
+.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
+.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
+.colist td:not([class]):first-child img{max-width:none}
+.colist td:not([class]):last-child{padding:.25em 0}
+.thumb,.th{line-height:0;display:inline-block;border:4px solid #fff;box-shadow:0 0 0 1px #ddd}
+.imageblock.left{margin:.25em .625em 1.25em 0}
+.imageblock.right{margin:.25em 0 1.25em .625em}
+.imageblock>.title{margin-bottom:0}
+.imageblock.thumb,.imageblock.th{border-width:6px}
+.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
+.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
+.image.left{margin-right:.625em}
+.image.right{margin-left:.625em}
+a.image{text-decoration:none;display:inline-block}
+a.image object{pointer-events:none}
+sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
+sup.footnote a,sup.footnoteref a{text-decoration:none}
+sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
+#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
+#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
+#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
+#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
+#footnotes .footnote:last-of-type{margin-bottom:0}
+#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
+div.unbreakable{page-break-inside:avoid}
+.big{font-size:larger}
+.small{font-size:smaller}
+.underline{text-decoration:underline}
+.overline{text-decoration:overline}
+.line-through{text-decoration:line-through}
+.aqua{color:#00bfbf}
+.aqua-background{background:#00fafa}
+.black{color:#000}
+.black-background{background:#000}
+.blue{color:#0000bf}
+.blue-background{background:#0000fa}
+.fuchsia{color:#bf00bf}
+.fuchsia-background{background:#fa00fa}
+.gray{color:#606060}
+.gray-background{background:#7d7d7d}
+.green{color:#006000}
+.green-background{background:#007d00}
+.lime{color:#00bf00}
+.lime-background{background:#00fa00}
+.maroon{color:#600000}
+.maroon-background{background:#7d0000}
+.navy{color:#000060}
+.navy-background{background:#00007d}
+.olive{color:#606000}
+.olive-background{background:#7d7d00}
+.purple{color:#600060}
+.purple-background{background:#7d007d}
+.red{color:#bf0000}
+.red-background{background:#fa0000}
+.silver{color:#909090}
+.silver-background{background:#bcbcbc}
+.teal{color:#006060}
+.teal-background{background:#007d7d}
+.white{color:#bfbfbf}
+.white-background{background:#fafafa}
+.yellow{color:#bfbf00}
+.yellow-background{background:#fafa00}
+span.icon>.fa{cursor:default}
+a span.icon>.fa{cursor:inherit}
+.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
+.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
+.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
+.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
+.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
+.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
+.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);border-radius:50%;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
+.conum[data-value] *{color:#fff!important}
+.conum[data-value]+b{display:none}
+.conum[data-value]::after{content:attr(data-value)}
+pre .conum[data-value]{position:relative;top:-.125em}
+b.conum *{color:inherit!important}
+.conum:not([data-value]):empty{display:none}
+dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
+h1,h2,p,td.content,span.alt,summary{letter-spacing:-.01em}
+p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
+p,blockquote,dt,td.content,span.alt,summary{font-size:1.0625rem}
+p{margin-bottom:1.25rem}
+.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
+.exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
+.print-only{display:none!important}
+@page{margin:1.25cm .75cm}
+@media print{*{box-shadow:none!important;text-shadow:none!important}
+html{font-size:80%}
+a{color:inherit!important;text-decoration:underline!important}
+a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
+a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
+abbr[title]{border-bottom:1px dotted}
+abbr[title]::after{content:" (" attr(title) ")"}
+pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
+thead{display:table-header-group}
+svg{max-width:100%}
+p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
+h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
+#header,#content,#footnotes,#footer{max-width:none}
+#toc,.sidebarblock,.exampleblock>.content{background:none!important}
+#toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
+body.book #header{text-align:center}
+body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
+body.book #header .details{border:0!important;display:block;padding:0!important}
+body.book #header .details span:first-child{margin-left:0!important}
+body.book #header .details br{display:block}
+body.book #header .details br+span::before{content:none!important}
+body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
+body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
+.listingblock code[data-lang]::before{display:block}
+#footer{padding:0 .9375em}
+.hide-on-print{display:none!important}
+.print-only{display:block!important}
+.hide-for-print{display:none!important}
+.show-for-print{display:inherit!important}}
+@media amzn-kf8,print{#header>h1:first-child{margin-top:1.25rem}
+.sect1{padding:0!important}
+.sect1+.sect1{border:0}
+#footer{background:none}
+#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
+@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
+</style>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/styles/github.min.css">
+</head>
+<body class="book toc2 toc-left">
+<div id="header">
+<h1>API 문서</h1>
+<div class="details">
+<span id="revnumber">version 0.0.1-SNAPSHOT</span>
+</div>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_github_주소">GitHub 주소</a></li>
+<li><a href="#_user_문서">User 문서</a></li>
+</ul>
+</div>
+</div>
+<div id="content">
+<div class="sect1">
+<h2 id="_github_주소">GitHub 주소</h2>
+<div class="sectionbody">
+<div class="ulist">
+<ul>
+<li>
+<p><a href="https://github.com/dankookie-4983/4983-server">GitHub 주소</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_user_문서">User 문서</h2>
+<div class="sectionbody">
+<div class="ulist">
+<ul>
+<li>
+<p><a href="usedBook.html">UsedBook 문서</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+</div>
+<div id="footer">
+<div id="footer-text">
+Version 0.0.1-SNAPSHOT<br>
+Last updated 2023-08-28 21:11:42 +0900
+</div>
+</div>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>
+<script>
+if (!hljs.initHighlighting.called) {
+  hljs.initHighlighting.called = true
+  ;[].slice.call(document.querySelectorAll('pre.highlight > code[data-lang]')).forEach(function (el) { hljs.highlightBlock(el) })
+}
+</script>
+</body>
+</html>

--- a/src/main/resources/static/docs/usedBook.html
+++ b/src/main/resources/static/docs/usedBook.html
@@ -471,7 +471,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <h4 id="_request">Request</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/used-book-list?canBuy=false HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/used-book-list?canBuyElseAll=false HTTP/1.1
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -482,9 +482,9 @@ Host: localhost:8080</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json
-Content-Length: 305
+Content-Length: 307
 
-[{"imageUrl":"imageUrl","bookStatus":"SALE","name":"책이름","tradeAvailableDate":"2023-08-28","createdAt":"2023-08-28T22:56:26.352789","price":10000},{"imageUrl":"imageUrl","bookStatus":"TRADE","name":"책이름","tradeAvailableDate":"2023-08-28","createdAt":"2023-08-28T22:56:26.3528","price":100000}]</code></pre>
+[{"imageUrl":"imageUrl","bookStatus":"SALE","name":"책이름","tradeAvailableDate":"2023-08-28","createdAt":"2023-08-28T23:29:57.959047","price":10000},{"imageUrl":"imageUrl","bookStatus":"TRADE","name":"책이름","tradeAvailableDate":"2023-08-28","createdAt":"2023-08-28T23:29:57.959061","price":100000}]</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
@@ -541,7 +541,7 @@ Content-Length: 305
 <h4 id="_request_2">Request</h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/used-book-list/college-and-department?college=ENGINEERING%2CEDUCATION&amp;department=COMPUTER%2CSOFTWARE%2CKOREAN&amp;canBuy=false HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/used-book-list/college-and-department?college=ENGINEERING%2CEDUCATION&amp;department=COMPUTER%2CSOFTWARE%2CKOREAN&amp;canBuyElseAll=false HTTP/1.1
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -566,7 +566,7 @@ Host: localhost:8080</code></pre>
 <td class="tableblock halign-left valign-top"><p class="tableblock">학과 enum 리스트</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>canBuy</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>canBuyElseAll</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">구매 가능 여부</p></td>
 </tr>
 </tbody>
@@ -586,7 +586,7 @@ Host: localhost:8080</code></pre>
 Content-Type: application/json
 Content-Length: 307
 
-[{"imageUrl":"imageUrl","bookStatus":"SALE","name":"책이름","tradeAvailableDate":"2023-08-28","createdAt":"2023-08-28T22:56:26.434009","price":10000},{"imageUrl":"imageUrl","bookStatus":"TRADE","name":"책이름","tradeAvailableDate":"2023-08-28","createdAt":"2023-08-28T22:56:26.434014","price":100000}]</code></pre>
+[{"imageUrl":"imageUrl","bookStatus":"SALE","name":"책이름","tradeAvailableDate":"2023-08-28","createdAt":"2023-08-28T23:29:58.045575","price":10000},{"imageUrl":"imageUrl","bookStatus":"TRADE","name":"책이름","tradeAvailableDate":"2023-08-28","createdAt":"2023-08-28T23:29:58.045583","price":100000}]</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">

--- a/src/main/resources/static/docs/usedBook.html
+++ b/src/main/resources/static/docs/usedBook.html
@@ -1,0 +1,752 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 2.0.18">
+<title>메인 문서</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
+<style>
+/*! Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
+/* Uncomment the following line when using as a custom stylesheet */
+/* @import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700"; */
+html{font-family:sans-serif;-webkit-text-size-adjust:100%}
+a{background:none}
+a:focus{outline:thin dotted}
+a:active,a:hover{outline:0}
+h1{font-size:2em;margin:.67em 0}
+b,strong{font-weight:bold}
+abbr{font-size:.9em}
+abbr[title]{cursor:help;border-bottom:1px dotted #dddddf;text-decoration:none}
+dfn{font-style:italic}
+hr{height:0}
+mark{background:#ff0;color:#000}
+code,kbd,pre,samp{font-family:monospace;font-size:1em}
+pre{white-space:pre-wrap}
+q{quotes:"\201C" "\201D" "\2018" "\2019"}
+small{font-size:80%}
+sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
+sup{top:-.5em}
+sub{bottom:-.25em}
+img{border:0}
+svg:not(:root){overflow:hidden}
+figure{margin:0}
+audio,video{display:inline-block}
+audio:not([controls]){display:none;height:0}
+fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
+legend{border:0;padding:0}
+button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
+button,input{line-height:normal}
+button,select{text-transform:none}
+button,html input[type=button],input[type=reset],input[type=submit]{-webkit-appearance:button;cursor:pointer}
+button[disabled],html input[disabled]{cursor:default}
+input[type=checkbox],input[type=radio]{padding:0}
+button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
+textarea{overflow:auto;vertical-align:top}
+table{border-collapse:collapse;border-spacing:0}
+*,::before,::after{box-sizing:border-box}
+html,body{font-size:100%}
+body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;line-height:1;position:relative;cursor:auto;-moz-tab-size:4;-o-tab-size:4;tab-size:4;word-wrap:anywhere;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
+a:hover{cursor:pointer}
+img,object,embed{max-width:100%;height:auto}
+object,embed{height:100%}
+img{-ms-interpolation-mode:bicubic}
+.left{float:left!important}
+.right{float:right!important}
+.text-left{text-align:left!important}
+.text-right{text-align:right!important}
+.text-center{text-align:center!important}
+.text-justify{text-align:justify!important}
+.hide{display:none}
+img,object,svg{display:inline-block;vertical-align:middle}
+textarea{height:auto;min-height:50px}
+select{width:100%}
+.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
+div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0}
+a{color:#2156a5;text-decoration:underline;line-height:inherit}
+a:hover,a:focus{color:#1d4b8f}
+a img{border:0}
+p{line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
+p aside{font-size:.875em;line-height:1.35;font-style:italic}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
+h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
+h1{font-size:2.125em}
+h2{font-size:1.6875em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
+h4,h5{font-size:1.125em}
+h6{font-size:1em}
+hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em}
+em,i{font-style:italic;line-height:inherit}
+strong,b{font-weight:bold;line-height:inherit}
+small{font-size:60%;line-height:inherit}
+code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
+ul,ol,dl{line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
+ul,ol{margin-left:1.5em}
+ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0}
+ul.circle{list-style-type:circle}
+ul.disc{list-style-type:disc}
+ul.square{list-style-type:square}
+ul.circle ul:not([class]),ul.disc ul:not([class]),ul.square ul:not([class]){list-style:inherit}
+ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
+dl dt{margin-bottom:.3125em;font-weight:bold}
+dl dd{margin-bottom:1.25em}
+blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
+blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
+@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
+h1{font-size:2.75em}
+h2{font-size:2.3125em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
+h4{font-size:1.4375em}}
+table{background:#fff;margin-bottom:1.25em;border:1px solid #dedede;word-wrap:normal}
+table thead,table tfoot{background:#f7f8f7}
+table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
+table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
+table tr.even,table tr.alt{background:#f8f8f7}
+table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{line-height:1.6}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
+h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
+.center{margin-left:auto;margin-right:auto}
+.stretch{width:100%}
+.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
+.clearfix::after,.float-group::after{clear:both}
+:not(pre).nobreak{word-wrap:normal}
+:not(pre).nowrap{white-space:nowrap}
+:not(pre).pre-wrap{white-space:pre-wrap}
+:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed}
+pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
+pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
+pre>code{display:block}
+pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
+em em{font-style:normal}
+strong strong{font-weight:400}
+.keyseq{color:rgba(51,51,51,.8)}
+kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;border-radius:3px;box-shadow:0 1px 0 rgba(0,0,0,.2),inset 0 0 0 .1em #fff;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
+.keyseq kbd:first-child{margin-left:0}
+.keyseq kbd:last-child{margin-right:0}
+.menuseq,.menuref{color:#000}
+.menuseq b:not(.caret),.menuref{font-weight:inherit}
+.menuseq{word-spacing:-.02em}
+.menuseq b.caret{font-size:1.25em;line-height:.8}
+.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
+b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
+b.button::before{content:"[";padding:0 3px 0 2px}
+b.button::after{content:"]";padding:0 2px 0 3px}
+p a>code:hover{color:rgba(0,0,0,.9)}
+#header,#content,#footnotes,#footer{width:100%;margin:0 auto;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
+#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
+#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
+#content{margin-top:1.25em}
+#content::before{content:none}
+#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
+#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
+#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
+#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:flex;flex-flow:row wrap}
+#header .details span:first-child{margin-left:-.125em}
+#header .details span.email a{color:rgba(0,0,0,.85)}
+#header .details br{display:none}
+#header .details br+span::before{content:"\00a0\2013\00a0"}
+#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
+#header .details br+span#revremark::before{content:"\00a0|\00a0"}
+#header #revnumber{text-transform:capitalize}
+#header #revnumber::after{content:"\00a0"}
+#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #dddddf;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
+#toc{border-bottom:1px solid #e7e7e9;padding-bottom:.5em}
+#toc>ul{margin-left:.125em}
+#toc ul.sectlevel0>li>a{font-style:italic}
+#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
+#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
+#toc li{line-height:1.3334;margin-top:.3334em}
+#toc a{text-decoration:none}
+#toc a:active{text-decoration:underline}
+#toctitle{color:#7a2518;font-size:1.2em}
+@media screen and (min-width:768px){#toctitle{font-size:1.375em}
+body.toc2{padding-left:15em;padding-right:0}
+#toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
+#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
+#toc.toc2>ul{font-size:.9em;margin-bottom:0}
+#toc.toc2 ul ul{margin-left:0;padding-left:1em}
+#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
+body.toc2.toc-right{padding-left:0;padding-right:15em}
+body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9;left:auto;right:0}}
+@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
+#toc.toc2{width:20em}
+#toc.toc2 #toctitle{font-size:1.375em}
+#toc.toc2>ul{font-size:.95em}
+#toc.toc2 ul ul{padding-left:1.25em}
+body.toc2.toc-right{padding-left:0;padding-right:20em}}
+#content #toc{border:1px solid #e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;border-radius:4px}
+#content #toc>:first-child{margin-top:0}
+#content #toc>:last-child{margin-bottom:0}
+#footer{max-width:none;background:rgba(0,0,0,.8);padding:1.25em}
+#footer-text{color:hsla(0,0%,100%,.8);line-height:1.44}
+#content{margin-bottom:.625em}
+.sect1{padding-bottom:.625em}
+@media screen and (min-width:768px){#content{margin-bottom:1.25em}
+.sect1{padding-bottom:1.25em}}
+.sect1:last-child{padding-bottom:0}
+.sect1+.sect1{border-top:1px solid #e7e7e9}
+#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
+#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
+#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
+#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
+#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
+details,.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
+details{margin-left:1.25rem}
+details>summary{cursor:pointer;display:block;position:relative;line-height:1.6;margin-bottom:.625rem;outline:none;-webkit-tap-highlight-color:transparent}
+details>summary::-webkit-details-marker{display:none}
+details>summary::before{content:"";border:solid transparent;border-left:solid;border-width:.3em 0 .3em .5em;position:absolute;top:.5em;left:-1.25rem;transform:translateX(15%)}
+details[open]>summary::before{border:solid transparent;border-top:solid;border-width:.5em .3em 0;transform:translateY(15%)}
+details>summary::after{content:"";width:1.25rem;height:1em;position:absolute;top:.3em;left:-1.25rem}
+.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
+table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
+.paragraph.lead>p,#preamble>.sectionbody>[class=paragraph]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
+.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
+.admonitionblock>table td.icon{text-align:center;width:80px}
+.admonitionblock>table td.icon img{max-width:none}
+.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
+.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6);word-wrap:anywhere}
+.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
+.exampleblock>.content{border:1px solid #e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;border-radius:4px}
+.exampleblock>.content>:first-child{margin-top:0}
+.exampleblock>.content>:last-child{margin-bottom:0}
+.sidebarblock{border:1px solid #dbdbd6;margin-bottom:1.25em;padding:1.25em;background:#f3f3f2;border-radius:4px}
+.sidebarblock>:first-child{margin-top:0}
+.sidebarblock>:last-child{margin-bottom:0}
+.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
+.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
+.literalblock pre,.listingblock>.content>pre{border-radius:4px;overflow-x:auto;padding:1em;font-size:.8125em}
+@media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
+@media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
+.literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class=highlight],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
+.literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
+.listingblock>.content{position:relative}
+.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
+.listingblock:hover code[data-lang]::before{display:block}
+.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
+.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
+.listingblock pre.highlightjs{padding:0}
+.listingblock pre.highlightjs>code{padding:1em;border-radius:4px}
+.listingblock pre.prettyprint{border-width:0}
+.prettyprint{background:#f7f7f8}
+pre.prettyprint .linenums{line-height:1.45;margin-left:2em}
+pre.prettyprint li{background:none;list-style-type:inherit;padding-left:0}
+pre.prettyprint li code[data-lang]::before{opacity:1}
+pre.prettyprint li:not(:first-child) code[data-lang]::before{display:none}
+table.linenotable{border-collapse:separate;border:0;margin-bottom:0;background:none}
+table.linenotable td[class]{color:inherit;vertical-align:top;padding:0;line-height:inherit;white-space:normal}
+table.linenotable td.code{padding-left:.75em}
+table.linenotable td.linenos,pre.pygments .linenos{border-right:1px solid;opacity:.35;padding-right:.5em;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}
+pre.pygments span.linenos{display:inline-block;margin-right:.75em}
+.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
+.quoteblock:not(.excerpt)>.title{margin-left:-1.5em;margin-bottom:.75em}
+.quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
+.quoteblock blockquote{margin:0;padding:0;border:0}
+.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
+.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
+.quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
+.verseblock{margin:0 1em 1.25em}
+.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans-serif;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
+.verseblock pre strong{font-weight:400}
+.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
+.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
+.quoteblock .attribution br,.verseblock .attribution br{display:none}
+.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
+.quoteblock.abstract blockquote::before,.quoteblock.excerpt blockquote::before,.quoteblock .quoteblock blockquote::before{display:none}
+.quoteblock.abstract blockquote,.quoteblock.abstract p,.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{line-height:1.6;word-spacing:0}
+.quoteblock.abstract{margin:0 1em 1.25em;display:block}
+.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
+.quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
+.quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
+.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
+.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;font-size:.85rem;text-align:left;margin-right:0}
+p.tableblock:last-child{margin-bottom:0}
+td.tableblock>.content{margin-bottom:1.25em;word-wrap:anywhere}
+td.tableblock>.content>:last-child{margin-bottom:-1.25em}
+table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
+table.grid-all>*>tr>*{border-width:1px}
+table.grid-cols>*>tr>*{border-width:0 1px}
+table.grid-rows>*>tr>*{border-width:1px 0}
+table.frame-all{border-width:1px}
+table.frame-ends{border-width:1px 0}
+table.frame-sides{border-width:0 1px}
+table.frame-none>colgroup+*>:first-child>*,table.frame-sides>colgroup+*>:first-child>*{border-top-width:0}
+table.frame-none>:last-child>:last-child>*,table.frame-sides>:last-child>:last-child>*{border-bottom-width:0}
+table.frame-none>*>tr>:first-child,table.frame-ends>*>tr>:first-child{border-left-width:0}
+table.frame-none>*>tr>:last-child,table.frame-ends>*>tr>:last-child{border-right-width:0}
+table.stripes-all>*>tr,table.stripes-odd>*>tr:nth-of-type(odd),table.stripes-even>*>tr:nth-of-type(even),table.stripes-hover>*>tr:hover{background:#f8f8f7}
+th.halign-left,td.halign-left{text-align:left}
+th.halign-right,td.halign-right{text-align:right}
+th.halign-center,td.halign-center{text-align:center}
+th.valign-top,td.valign-top{vertical-align:top}
+th.valign-bottom,td.valign-bottom{vertical-align:bottom}
+th.valign-middle,td.valign-middle{vertical-align:middle}
+table thead th,table tfoot th{font-weight:bold}
+tbody tr th{background:#f7f8f7}
+tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
+p.tableblock>code:only-child{background:none;padding:0}
+p.tableblock{font-size:1em}
+ol{margin-left:1.75em}
+ul li ol{margin-left:1.5em}
+dl dd{margin-left:1.125em}
+dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
+li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
+ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
+ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
+ul.unstyled,ol.unstyled{margin-left:0}
+li>p:empty:only-child::before{content:"";display:inline-block}
+ul.checklist>li>p:first-child{margin-left:-1em}
+ul.checklist>li>p:first-child>.fa-square-o:first-child,ul.checklist>li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
+ul.checklist>li>p:first-child>input[type=checkbox]:first-child{margin-right:.25em}
+ul.inline{display:flex;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
+ul.inline>li{margin-left:1.25em}
+.unstyled dl dt{font-weight:400;font-style:normal}
+ol.arabic{list-style-type:decimal}
+ol.decimal{list-style-type:decimal-leading-zero}
+ol.loweralpha{list-style-type:lower-alpha}
+ol.upperalpha{list-style-type:upper-alpha}
+ol.lowerroman{list-style-type:lower-roman}
+ol.upperroman{list-style-type:upper-roman}
+ol.lowergreek{list-style-type:lower-greek}
+.hdlist>table,.colist>table{border:0;background:none}
+.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
+td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
+td.hdlist1{font-weight:bold;padding-bottom:1.25em}
+td.hdlist2{word-wrap:anywhere}
+.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
+.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
+.colist td:not([class]):first-child img{max-width:none}
+.colist td:not([class]):last-child{padding:.25em 0}
+.thumb,.th{line-height:0;display:inline-block;border:4px solid #fff;box-shadow:0 0 0 1px #ddd}
+.imageblock.left{margin:.25em .625em 1.25em 0}
+.imageblock.right{margin:.25em 0 1.25em .625em}
+.imageblock>.title{margin-bottom:0}
+.imageblock.thumb,.imageblock.th{border-width:6px}
+.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
+.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
+.image.left{margin-right:.625em}
+.image.right{margin-left:.625em}
+a.image{text-decoration:none;display:inline-block}
+a.image object{pointer-events:none}
+sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
+sup.footnote a,sup.footnoteref a{text-decoration:none}
+sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
+#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
+#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
+#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
+#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
+#footnotes .footnote:last-of-type{margin-bottom:0}
+#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
+div.unbreakable{page-break-inside:avoid}
+.big{font-size:larger}
+.small{font-size:smaller}
+.underline{text-decoration:underline}
+.overline{text-decoration:overline}
+.line-through{text-decoration:line-through}
+.aqua{color:#00bfbf}
+.aqua-background{background:#00fafa}
+.black{color:#000}
+.black-background{background:#000}
+.blue{color:#0000bf}
+.blue-background{background:#0000fa}
+.fuchsia{color:#bf00bf}
+.fuchsia-background{background:#fa00fa}
+.gray{color:#606060}
+.gray-background{background:#7d7d7d}
+.green{color:#006000}
+.green-background{background:#007d00}
+.lime{color:#00bf00}
+.lime-background{background:#00fa00}
+.maroon{color:#600000}
+.maroon-background{background:#7d0000}
+.navy{color:#000060}
+.navy-background{background:#00007d}
+.olive{color:#606000}
+.olive-background{background:#7d7d00}
+.purple{color:#600060}
+.purple-background{background:#7d007d}
+.red{color:#bf0000}
+.red-background{background:#fa0000}
+.silver{color:#909090}
+.silver-background{background:#bcbcbc}
+.teal{color:#006060}
+.teal-background{background:#007d7d}
+.white{color:#bfbfbf}
+.white-background{background:#fafafa}
+.yellow{color:#bfbf00}
+.yellow-background{background:#fafa00}
+span.icon>.fa{cursor:default}
+a span.icon>.fa{cursor:inherit}
+.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
+.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
+.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
+.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
+.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
+.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
+.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);border-radius:50%;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
+.conum[data-value] *{color:#fff!important}
+.conum[data-value]+b{display:none}
+.conum[data-value]::after{content:attr(data-value)}
+pre .conum[data-value]{position:relative;top:-.125em}
+b.conum *{color:inherit!important}
+.conum:not([data-value]):empty{display:none}
+dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
+h1,h2,p,td.content,span.alt,summary{letter-spacing:-.01em}
+p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
+p,blockquote,dt,td.content,span.alt,summary{font-size:1.0625rem}
+p{margin-bottom:1.25rem}
+.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
+.exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
+.print-only{display:none!important}
+@page{margin:1.25cm .75cm}
+@media print{*{box-shadow:none!important;text-shadow:none!important}
+html{font-size:80%}
+a{color:inherit!important;text-decoration:underline!important}
+a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
+a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
+abbr[title]{border-bottom:1px dotted}
+abbr[title]::after{content:" (" attr(title) ")"}
+pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
+thead{display:table-header-group}
+svg{max-width:100%}
+p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
+h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
+#header,#content,#footnotes,#footer{max-width:none}
+#toc,.sidebarblock,.exampleblock>.content{background:none!important}
+#toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
+body.book #header{text-align:center}
+body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
+body.book #header .details{border:0!important;display:block;padding:0!important}
+body.book #header .details span:first-child{margin-left:0!important}
+body.book #header .details br{display:block}
+body.book #header .details br+span::before{content:none!important}
+body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
+body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
+.listingblock code[data-lang]::before{display:block}
+#footer{padding:0 .9375em}
+.hide-on-print{display:none!important}
+.print-only{display:block!important}
+.hide-for-print{display:none!important}
+.show-for-print{display:inherit!important}}
+@media amzn-kf8,print{#header>h1:first-child{margin-top:1.25rem}
+.sect1{padding:0!important}
+.sect1+.sect1{border:0}
+#footer{background:none}
+#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
+@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
+</style>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/styles/github.min.css">
+</head>
+<body class="book toc2 toc-left">
+<div id="header">
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_메인_문서">메인 문서</a></li>
+<li><a href="#_usedbook_메인페이지_관련_문서">UsedBook 메인페이지 관련 문서</a>
+<ul class="sectlevel2">
+<li><a href="#_조건없는_책_리스트_가져오기_판매중_거래중_판매완료_순으로_보이고_각각_날짜에_따라_최신순으로_정렬">조건없는 책 리스트 가져오기 (판매중, 거래중, 판매완료 순으로 보이고 각각 날짜에 따라 최신순으로 정렬)</a></li>
+<li><a href="#_단과대_학과에_따라_서적_리스트_가져오기">단과대 학과에 따라 서적 리스트 가져오기</a></li>
+</ul>
+</li>
+</ul>
+</div>
+</div>
+<div id="content">
+<div class="sect1">
+<h2 id="_메인_문서">메인 문서</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p><a href="index.html">메인 문서</a></p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_usedbook_메인페이지_관련_문서">UsedBook 메인페이지 관련 문서</h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_조건없는_책_리스트_가져오기_판매중_거래중_판매완료_순으로_보이고_각각_날짜에_따라_최신순으로_정렬">조건없는 책 리스트 가져오기 (판매중, 거래중, 판매완료 순으로 보이고 각각 날짜에 따라 최신순으로 정렬)</h3>
+<div class="sect3">
+<h4 id="_request">Request</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/used-book-list?canBuy=false HTTP/1.1
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response">Response</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 305
+
+[{"imageUrl":"imageUrl","bookStatus":"SALE","name":"책이름","tradeAvailableDate":"2023-08-28","createdAt":"2023-08-28T22:56:26.352789","price":10000},{"imageUrl":"imageUrl","bookStatus":"TRADE","name":"책이름","tradeAvailableDate":"2023-08-28","createdAt":"2023-08-28T22:56:26.3528","price":100000}]</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].imageUrl</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">책 이미지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].bookStatus</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">책 상태</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].name</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">책 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].tradeAvailableDate</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">거래 가능 날짜</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].createdAt</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">책 등록 날짜</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].price</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">책 가격</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_단과대_학과에_따라_서적_리스트_가져오기">단과대 학과에 따라 서적 리스트 가져오기</h3>
+<div class="sect3">
+<h4 id="_request_2">Request</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/used-book-list/college-and-department?college=ENGINEERING%2CEDUCATION&amp;department=COMPUTER%2CSOFTWARE%2CKOREAN&amp;canBuy=false HTTP/1.1
+Host: localhost:8080</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>college</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">단과대학 enum 리스트</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>department</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">학과 enum 리스트</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>canBuy</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">구매 가능 여부</p></td>
+</tr>
+</tbody>
+</table>
+<div class="sect4">
+<h5 id="_queryparameter_예시">QueryParameter 예시</h5>
+<div class="paragraph">
+<p>api?college=ENGINEERING,EDUCATION&amp;department=COMPUTER,SOFTWARE,KOREAN</p>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_2">Response</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 307
+
+[{"imageUrl":"imageUrl","bookStatus":"SALE","name":"책이름","tradeAvailableDate":"2023-08-28","createdAt":"2023-08-28T22:56:26.434009","price":10000},{"imageUrl":"imageUrl","bookStatus":"TRADE","name":"책이름","tradeAvailableDate":"2023-08-28","createdAt":"2023-08-28T22:56:26.434014","price":100000}]</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].imageUrl</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">책 이미지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].bookStatus</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">책 상태</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].name</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">책 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].tradeAvailableDate</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">거래 가능 날짜</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].createdAt</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">책 등록 날짜</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].price</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">책 가격</p></td>
+</tr>
+</tbody>
+</table>
+<div class="sect4">
+<h5 id="_college_enum_앞의_영어만_보면됨">College Enum (앞의 영어만 보면됨)</h5>
+<div class="literalblock">
+<div class="content">
+<pre>BUSINESS_AND_ECONOMICS("경영경제대학" ),
+SW_CONVERGENCE("SW융합대학"),
+SOCIAL_SCIENCES("사회과학대학"),
+LITERAL_ARTS("문과대학"),
+LAW("법과대학"),
+ENGINEERING("공과대학"),
+EDUCATION("사범대학"),
+MUSIC_AND_ARTS("음악예술대학");</pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_department_enum_앞에_영어만_보면됨">Department Enum (앞에 영어만 보면됨)</h5>
+<div class="literalblock">
+<div class="content">
+<pre>BUSINESS("경영학과", BUSINESS_AND_ECONOMICS),
+ECONOMICS("경제학과", BUSINESS_AND_ECONOMICS),
+INTERNATIONAL_BUSINESS("국제경영학전공", BUSINESS_AND_ECONOMICS),
+TRADE("무역학과", BUSINESS_AND_ECONOMICS),
+INDUSTRIAL_BUSINESS("산업경영학과", BUSINESS_AND_ECONOMICS),
+ACCOUNTING("회계학과", BUSINESS_AND_ECONOMICS),</pre>
+</div>
+</div>
+<div class="literalblock">
+<div class="content">
+<pre>POLITICAL("정치외교학과", SOCIAL_SCIENCES),
+PUBLIC_ADMINISTRATION("행정학과", SOCIAL_SCIENCES),
+URBAN_PLANNING("도시계획부동산학부", SOCIAL_SCIENCES),
+MEDIA_COMMUNICATION("미디어커뮤니케이션학부", SOCIAL_SCIENCES),
+CONSULTING("상담학과", SOCIAL_SCIENCES),</pre>
+</div>
+</div>
+<div class="literalblock">
+<div class="content">
+<pre>DEPARTMENT_OF_LAW("법학과", LAW),</pre>
+</div>
+</div>
+<div class="literalblock">
+<div class="content">
+<pre>KOREAN("국어국문과", LITERAL_ARTS),
+HISTORY("사학과", LITERAL_ARTS),
+PHILOSOPHY("철학과", LITERAL_ARTS),
+AMERICAN_HUMANITY("영미인문학과", LITERAL_ARTS),</pre>
+</div>
+</div>
+<div class="literalblock">
+<div class="content">
+<pre>ELECTRICAL("전자전기공학전공", ENGINEERING),
+POLYMER("고분자공학전공", ENGINEERING),
+FUSION_SEMICONDUCTOR("융합반도체공학전공", ENGINEERING),
+FIBER("파이버융합소재공학전공", ENGINEERING),
+CHEMICAL("화학공학과", ENGINEERING),
+ARCHITECTURE_ENGINEER("건축공학전공", ENGINEERING),
+ARCHITECTURE("건축학전공", ENGINEERING),</pre>
+</div>
+</div>
+<div class="literalblock">
+<div class="content">
+<pre>SOFTWARE("소프트웨어학과", SW_CONVERGENCE),
+COMPUTER("컴퓨터공학과", SW_CONVERGENCE),
+MOBILE_SYSTEM("모바일시스템공학과", SW_CONVERGENCE),
+STATISTICS("정보통계학과", SW_CONVERGENCE),
+SECURITY("산업보안학과", SW_CONVERGENCE),</pre>
+</div>
+</div>
+<div class="literalblock">
+<div class="content">
+<pre>MATH("수학교육과", EDUCATION),
+SCIENCE("과학교육과", EDUCATION),
+ATHLETIC("체육교육과", EDUCATION),
+CHINESE("한문교육과", EDUCATION),
+SPECIAL("특수교육과", EDUCATION),</pre>
+</div>
+</div>
+<div class="literalblock">
+<div class="content">
+<pre>MOVIE("영화전공", MUSIC_AND_ARTS),
+THEATER("연극전공", MUSIC_AND_ARTS),
+MUSICAL("뮤지컬전공", MUSIC_AND_ARTS),
+CERAMICS("도예과", MUSIC_AND_ARTS),
+COMMUNICATION_DESIGN("커뮤니케이션디자인전공", MUSIC_AND_ARTS),
+INDUSTRIAL_DESIGN("패션산업디자인전공", MUSIC_AND_ARTS),
+DANCING("무용과", MUSIC_AND_ARTS),
+PIANO("피아노전공", MUSIC_AND_ARTS),
+VOCAL("성악전공", MUSIC_AND_ARTS),
+ORCHESTRA("관현악전공", MUSIC_AND_ARTS),
+COMPOSITION("작곡전공", MUSIC_AND_ARTS),
+GUGAK("국악전공", MUSIC_AND_ARTS);</pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div id="footer">
+<div id="footer-text">
+Version 0.0.1-SNAPSHOT<br>
+Last updated 2023-08-28 22:22:16 +0900
+</div>
+</div>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>
+<script>
+if (!hljs.initHighlighting.called) {
+  hljs.initHighlighting.called = true
+  ;[].slice.call(document.querySelectorAll('pre.highlight > code[data-lang]')).forEach(function (el) { hljs.highlightBlock(el) })
+}
+</script>
+</body>
+</html>

--- a/src/test/java/team/dankookie/server4983/book/controller/UsedBookListControllerTest.java
+++ b/src/test/java/team/dankookie/server4983/book/controller/UsedBookListControllerTest.java
@@ -1,0 +1,189 @@
+package team.dankookie.server4983.book.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import team.dankookie.server4983.book.constant.BookStatus;
+import team.dankookie.server4983.book.constant.College;
+import team.dankookie.server4983.book.constant.Department;
+import team.dankookie.server4983.book.dto.UsedBookListResponse;
+import team.dankookie.server4983.book.service.UsedBookListService;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SpringBootTest
+@AutoConfigureRestDocs
+@ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
+@MockBean(JpaMetamodelMappingContext.class)
+@WebAppConfiguration
+class UsedBookListControllerTest {
+
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockBean
+    UsedBookListService usedBookListService;
+
+    @BeforeEach
+    public void init(WebApplicationContext webApplicationContext,
+                     RestDocumentationContextProvider restDocumentation) {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+                .apply(documentationConfiguration(restDocumentation))
+                .build();
+    }
+
+    final String API = "/api/used-book-list";
+
+    @Test
+    void 서적의_모든_리스트를_반환한다() throws Exception {
+        //given
+        final boolean canBuy = false;
+
+        UsedBookListResponse usedBookListResponse1 = UsedBookListResponse.builder()
+                .imageUrl("imageUrl")
+                .bookStatus(BookStatus.SALE)
+                .name("책이름")
+                .tradeAvailableDate(LocalDate.now())
+                .createdAt(LocalDateTime.now())
+                .price(10000)
+                .build();
+
+        UsedBookListResponse usedBookListResponse2 = UsedBookListResponse.builder()
+                .imageUrl("imageUrl")
+                .bookStatus(BookStatus.TRADE)
+                .name("책이름")
+                .tradeAvailableDate(LocalDate.now())
+                .createdAt(LocalDateTime.now())
+                .price(100000)
+                .build();
+
+        final List<UsedBookListResponse> usedBookListResponseList = List.of(
+                usedBookListResponse1, usedBookListResponse2
+        );
+
+        when(usedBookListService.getUsedBookList(false))
+                .thenReturn(usedBookListResponseList);
+
+        //when
+        ResultActions resultActions = mockMvc.perform(get(API)
+                        .queryParam("canBuy", String.valueOf(canBuy)))
+                .andDo(print());
+
+        //then
+        resultActions.andExpect(status().isOk())
+                .andDo(
+                        document("used-book-list/getUsedBookList/success",
+                                queryParameters(
+                                        parameterWithName("canBuy").description("구매 가능 여부")
+                                ),
+                                responseFields(
+                                        fieldWithPath("[].imageUrl").description("책 이미지"),
+                                        fieldWithPath("[].bookStatus").description("책 상태"),
+                                        fieldWithPath("[].name").description("책 이름"),
+                                        fieldWithPath("[].tradeAvailableDate").description("거래 가능 날짜"),
+                                        fieldWithPath("[].createdAt").description("책 등록 날짜"),
+                                        fieldWithPath("[].price").description("책 가격")
+                                )
+                        ));
+
+    }
+
+    @Test
+    void 서적을_단과대와_학과에따라_리스트로_반환한다() throws Exception {
+        //given
+        final String URL = API + "/college-and-department";
+        final boolean canBuy = false;
+
+        UsedBookListResponse usedBookListResponse1 = UsedBookListResponse.builder()
+                .imageUrl("imageUrl")
+                .bookStatus(BookStatus.SALE)
+                .name("책이름")
+                .tradeAvailableDate(LocalDate.now())
+                .createdAt(LocalDateTime.now())
+                .price(10000)
+                .build();
+
+        UsedBookListResponse usedBookListResponse2 = UsedBookListResponse.builder()
+                .imageUrl("imageUrl")
+                .bookStatus(BookStatus.TRADE)
+                .name("책이름")
+                .tradeAvailableDate(LocalDate.now())
+                .createdAt(LocalDateTime.now())
+                .price(100000)
+                .build();
+
+        final List<UsedBookListResponse> usedBookListResponseList = List.of(
+                usedBookListResponse1, usedBookListResponse2
+        );
+
+        List<College> collegeList = List.of(College.ENGINEERING, College.EDUCATION);
+        List<Department> departmentList = List.of(Department.COMPUTER, Department.SOFTWARE, Department.KOREAN);
+
+        when(usedBookListService.getUsedBookList(collegeList, departmentList, canBuy))
+                .thenReturn(usedBookListResponseList);
+
+        //when
+        ResultActions resultActions = mockMvc.perform(get(URL)
+                        .param("college", "ENGINEERING,EDUCATION")
+                        .param("department", "COMPUTER,SOFTWARE,KOREAN")
+                        .param("canBuy", String.valueOf(canBuy))
+                )
+                .andDo(print());
+
+        //then
+        resultActions.andExpect(status().isOk())
+                .andDo(
+                        document("used-book-list/getUsedBookListWithCollegeAndDepartment/success",
+                                queryParameters(
+                                        parameterWithName("college").description("단과대학 enum 리스트"),
+                                        parameterWithName("department").description("학과 enum 리스트"),
+                                        parameterWithName("canBuy").description("구매 가능 여부")
+                                ),
+                                responseFields(
+                                        fieldWithPath("[].imageUrl").description("책 이미지"),
+                                        fieldWithPath("[].bookStatus").description("책 상태"),
+                                        fieldWithPath("[].name").description("책 이름"),
+                                        fieldWithPath("[].tradeAvailableDate").description("거래 가능 날짜"),
+                                        fieldWithPath("[].createdAt").description("책 등록 날짜"),
+                                        fieldWithPath("[].price").description("책 가격")
+                                )
+                        ));
+
+    }
+
+
+
+}

--- a/src/test/java/team/dankookie/server4983/book/controller/UsedBookListControllerTest.java
+++ b/src/test/java/team/dankookie/server4983/book/controller/UsedBookListControllerTest.java
@@ -70,7 +70,7 @@ class UsedBookListControllerTest {
     @Test
     void 서적의_모든_리스트를_반환한다() throws Exception {
         //given
-        final boolean canBuy = false;
+        final boolean canBuyElseAll = false;
 
         UsedBookListResponse usedBookListResponse1 = UsedBookListResponse.builder()
                 .imageUrl("imageUrl")
@@ -99,7 +99,7 @@ class UsedBookListControllerTest {
 
         //when
         ResultActions resultActions = mockMvc.perform(get(API)
-                        .queryParam("canBuy", String.valueOf(canBuy)))
+                        .queryParam("canBuyElseAll", String.valueOf(canBuyElseAll)))
                 .andDo(print());
 
         //then
@@ -107,7 +107,7 @@ class UsedBookListControllerTest {
                 .andDo(
                         document("used-book-list/getUsedBookList/success",
                                 queryParameters(
-                                        parameterWithName("canBuy").description("구매 가능 여부")
+                                        parameterWithName("canBuyElseAll").description("구매 가능 여부")
                                 ),
                                 responseFields(
                                         fieldWithPath("[].imageUrl").description("책 이미지"),
@@ -125,7 +125,7 @@ class UsedBookListControllerTest {
     void 서적을_단과대와_학과에따라_리스트로_반환한다() throws Exception {
         //given
         final String URL = API + "/college-and-department";
-        final boolean canBuy = false;
+        final boolean canBuyElseAll = false;
 
         UsedBookListResponse usedBookListResponse1 = UsedBookListResponse.builder()
                 .imageUrl("imageUrl")
@@ -152,14 +152,14 @@ class UsedBookListControllerTest {
         List<College> collegeList = List.of(College.ENGINEERING, College.EDUCATION);
         List<Department> departmentList = List.of(Department.COMPUTER, Department.SOFTWARE, Department.KOREAN);
 
-        when(usedBookListService.getUsedBookList(collegeList, departmentList, canBuy))
+        when(usedBookListService.getUsedBookList(collegeList, departmentList, canBuyElseAll))
                 .thenReturn(usedBookListResponseList);
 
         //when
         ResultActions resultActions = mockMvc.perform(get(URL)
                         .param("college", "ENGINEERING,EDUCATION")
                         .param("department", "COMPUTER,SOFTWARE,KOREAN")
-                        .param("canBuy", String.valueOf(canBuy))
+                        .param("canBuyElseAll", String.valueOf(canBuyElseAll))
                 )
                 .andDo(print());
 
@@ -170,7 +170,7 @@ class UsedBookListControllerTest {
                                 queryParameters(
                                         parameterWithName("college").description("단과대학 enum 리스트"),
                                         parameterWithName("department").description("학과 enum 리스트"),
-                                        parameterWithName("canBuy").description("구매 가능 여부")
+                                        parameterWithName("canBuyElseAll").description("구매 가능 여부")
                                 ),
                                 responseFields(
                                         fieldWithPath("[].imageUrl").description("책 이미지"),

--- a/src/test/java/team/dankookie/server4983/book/repository/usedBook/UsedBookRepositoryTest.java
+++ b/src/test/java/team/dankookie/server4983/book/repository/usedBook/UsedBookRepositoryTest.java
@@ -1,0 +1,293 @@
+package team.dankookie.server4983.book.repository.usedBook;
+
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import team.dankookie.server4983.book.constant.BookStatus;
+import team.dankookie.server4983.book.constant.College;
+import team.dankookie.server4983.book.constant.Department;
+import team.dankookie.server4983.book.domain.UsedBook;
+import team.dankookie.server4983.config.TestConfig;
+import team.dankookie.server4983.member.constant.AccountBank;
+import team.dankookie.server4983.member.domain.Member;
+import team.dankookie.server4983.member.repository.MemberRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@DataJpaTest
+@Import(TestConfig.class)
+class UsedBookRepositoryTest {
+
+    @Autowired
+    UsedBookRepository usedBookRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Test
+    void 모든_서적을_리턴한다() {
+        //given
+        final boolean canBuyElseAll = false;
+
+        Member member = Member.builder()
+                .accountBank(AccountBank.K)
+                .department(Department.DEPARTMENT_OF_LAW)
+                .accountHolder("홍길동")
+                .phoneNumber("010-1234-5678")
+                .password("password")
+                .nickname("nickname")
+                .yearOfAdmission(2022)
+                .studentId("20151234")
+                .accountNumber("123123123")
+                .build();
+
+        memberRepository.save(member);
+
+        UsedBook usedBookSale = UsedBook.builder()
+                .bookStatus(BookStatus.SALE)
+                .buyerMember(member)
+                .tradeAvailableDate(LocalDate.now())
+                .price(10000)
+                .name("책이름")
+                .build();
+
+        UsedBook usedBookTrade = UsedBook.builder()
+                .bookStatus(BookStatus.TRADE)
+                .buyerMember(member)
+                .tradeAvailableDate(LocalDate.now())
+                .price(10000)
+                .name("책이름")
+                .build();
+
+        UsedBook usedBookSold = UsedBook.builder()
+                .bookStatus(BookStatus.SOLD)
+                .buyerMember(member)
+                .tradeAvailableDate(LocalDate.now())
+                .price(10000)
+                .name("책이름")
+                .build();
+
+
+
+        usedBookRepository.save(usedBookSold);
+        usedBookRepository.save(usedBookTrade);
+        usedBookRepository.save(usedBookSale);
+
+
+        //when
+        List<UsedBook> usedBookList = usedBookRepository.getUsedBookList(canBuyElseAll);
+
+        //then
+        assertThat(usedBookList).hasSize(3);
+        assertThat(usedBookList.get(0).getBookStatus()).isEqualTo(BookStatus.SALE);
+        assertThat(usedBookList.get(1).getBookStatus()).isEqualTo(BookStatus.TRADE);
+        assertThat(usedBookList.get(2).getBookStatus()).isEqualTo(BookStatus.SOLD);
+    }
+
+    @Test
+    void 서적을_단과대와_학과에_따라_리턴한다() {
+        //given
+        final boolean canBuyElseAll = false;
+        final List<Department> departmentList = List.of(Department.DEPARTMENT_OF_LAW);
+        final List<College> collegeList = List.of(College.LAW);
+
+
+        Member member = Member.builder()
+                .department(Department.DEPARTMENT_OF_LAW)
+                .accountBank(AccountBank.K)
+                .accountHolder("홍길동")
+                .phoneNumber("010-1234-5678")
+                .password("password")
+                .nickname("nickname")
+                .yearOfAdmission(2022)
+                .studentId("20151234")
+                .accountNumber("123123123")
+                .build();
+
+        memberRepository.save(member);
+
+        UsedBook usedBookWantToFind1 = UsedBook.builder()
+                .college(collegeList.get(0))
+                .department(departmentList.get(0))
+                .bookStatus(BookStatus.SALE)
+                .buyerMember(member)
+                .tradeAvailableDate(LocalDate.now())
+                .price(10000)
+                .name("책이름")
+                .build();
+
+        UsedBook usedBookWantToFind2 = UsedBook.builder()
+                .college(collegeList.get(0))
+                .department(departmentList.get(0))
+                .bookStatus(BookStatus.SALE)
+                .buyerMember(member)
+                .tradeAvailableDate(LocalDate.now())
+                .price(10000)
+                .name("책이름")
+                .build();
+
+        UsedBook usedBookElse = UsedBook.builder()
+                .college(College.BUSINESS_AND_ECONOMICS)
+                .department(Department.ACCOUNTING)
+                .buyerMember(member)
+                .tradeAvailableDate(LocalDate.now())
+                .bookStatus(BookStatus.SALE)
+                .price(10000)
+                .name("책이름")
+                .build();
+
+
+        usedBookRepository.save(usedBookWantToFind1);
+        usedBookRepository.save(usedBookWantToFind2);
+        usedBookRepository.save(usedBookElse);
+
+
+        //when
+        List<UsedBook> usedBookList = usedBookRepository.getUsedBookListInCollegeAndDepartment(collegeList, departmentList, canBuyElseAll);
+
+        //then
+        assertThat(usedBookList).hasSize(2);
+    }
+
+    @Test
+    void 서적을_단과대에_따라_리턴한다() {
+        //given
+        final boolean canBuyElseAll = false;
+        final List<Department> departmentList = List.of(Department.DEPARTMENT_OF_LAW);
+        final List<College> collegeList = List.of(College.LAW);
+
+
+        Member member = Member.builder()
+                .department(Department.DEPARTMENT_OF_LAW)
+                .accountBank(AccountBank.K)
+                .accountHolder("홍길동")
+                .phoneNumber("010-1234-5678")
+                .password("password")
+                .nickname("nickname")
+                .yearOfAdmission(2022)
+                .studentId("20151234")
+                .accountNumber("123123123")
+                .build();
+
+        memberRepository.save(member);
+
+        UsedBook usedBookWantToFind1 = UsedBook.builder()
+                .college(collegeList.get(0))
+                .department(departmentList.get(0))
+                .bookStatus(BookStatus.SALE)
+                .buyerMember(member)
+                .tradeAvailableDate(LocalDate.now())
+                .price(10000)
+                .name("책이름")
+                .build();
+
+        UsedBook usedBookWantToFind2 = UsedBook.builder()
+                .college(collegeList.get(0))
+                .department(departmentList.get(0))
+                .bookStatus(BookStatus.SALE)
+                .buyerMember(member)
+                .tradeAvailableDate(LocalDate.now())
+                .price(10000)
+                .name("책이름")
+                .build();
+
+        UsedBook usedBookElse = UsedBook.builder()
+                .college(College.BUSINESS_AND_ECONOMICS)
+                .department(Department.ACCOUNTING)
+                .buyerMember(member)
+                .tradeAvailableDate(LocalDate.now())
+                .bookStatus(BookStatus.SALE)
+                .price(10000)
+                .name("책이름")
+                .build();
+
+
+        usedBookRepository.save(usedBookWantToFind1);
+        usedBookRepository.save(usedBookWantToFind2);
+        usedBookRepository.save(usedBookElse);
+
+
+        //when
+        List<UsedBook> usedBookList = usedBookRepository.getUsedBookListInCollegeAndDepartment(collegeList, List.of(), canBuyElseAll);
+
+        //then
+        assertThat(usedBookList).hasSize(2);
+    }
+
+    @Test
+    void 서적을_학과에_따라_리턴한다() {
+        //given
+        final boolean canBuyElseAll = false;
+        final List<Department> departmentList = List.of(Department.DEPARTMENT_OF_LAW);
+        final List<College> collegeList = List.of(College.LAW);
+
+
+        Member member = Member.builder()
+                .department(Department.DEPARTMENT_OF_LAW)
+                .accountBank(AccountBank.K)
+                .accountHolder("홍길동")
+                .phoneNumber("010-1234-5678")
+                .password("password")
+                .nickname("nickname")
+                .yearOfAdmission(2022)
+                .studentId("20151234")
+                .accountNumber("123123123")
+                .build();
+
+        memberRepository.save(member);
+
+        UsedBook usedBookWantToFind1 = UsedBook.builder()
+                .college(collegeList.get(0))
+                .department(departmentList.get(0))
+                .bookStatus(BookStatus.SALE)
+                .buyerMember(member)
+                .tradeAvailableDate(LocalDate.now())
+                .price(10000)
+                .name("책이름")
+                .build();
+
+        UsedBook usedBookWantToFind2 = UsedBook.builder()
+                .college(collegeList.get(0))
+                .department(departmentList.get(0))
+                .bookStatus(BookStatus.SALE)
+                .buyerMember(member)
+                .tradeAvailableDate(LocalDate.now())
+                .price(10000)
+                .name("책이름")
+                .build();
+
+        UsedBook usedBookElse = UsedBook.builder()
+                .college(College.BUSINESS_AND_ECONOMICS)
+                .department(Department.ACCOUNTING)
+                .buyerMember(member)
+                .tradeAvailableDate(LocalDate.now())
+                .bookStatus(BookStatus.SALE)
+                .price(10000)
+                .name("책이름")
+                .build();
+
+
+        usedBookRepository.save(usedBookWantToFind1);
+        usedBookRepository.save(usedBookWantToFind2);
+        usedBookRepository.save(usedBookElse);
+
+
+        //when
+        List<UsedBook> usedBookList = usedBookRepository.getUsedBookListInCollegeAndDepartment(List.of(), departmentList, canBuyElseAll);
+
+        //then
+        assertThat(usedBookList).hasSize(2);
+    }
+
+
+}

--- a/src/test/java/team/dankookie/server4983/book/service/UsedBookListServiceTest.java
+++ b/src/test/java/team/dankookie/server4983/book/service/UsedBookListServiceTest.java
@@ -1,0 +1,72 @@
+package team.dankookie.server4983.book.service;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.dankookie.server4983.book.constant.BookStatus;
+import team.dankookie.server4983.book.domain.UsedBook;
+import team.dankookie.server4983.book.dto.UsedBookListResponse;
+import team.dankookie.server4983.book.repository.bookImage.BookImageRepository;
+import team.dankookie.server4983.book.repository.usedBook.UsedBookRepository;
+import team.dankookie.server4983.member.domain.Member;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@ExtendWith(MockitoExtension.class)
+class UsedBookListServiceTest {
+
+    @InjectMocks
+    UsedBookListService usedBookListService;
+
+    @Mock
+    UsedBookRepository usedBookRepository;
+
+    @Mock
+    BookImageRepository bookImageRepository;
+
+    @Test
+    void 판매중인_책의_리스트를_리턴한다() {
+        //given
+        final String imageUrl = "imageUrl";
+        final boolean canBuy = false;
+
+        final UsedBook book1 = createBook();
+        final UsedBook book2 = createBook();
+
+        when(usedBookRepository.getUsedBookList(canBuy))
+                .thenReturn(List.of(book1, book2));
+        when(bookImageRepository.getBookImageUrlByUsedBookId(any()))
+                .thenReturn(imageUrl);
+        //when
+        List<UsedBookListResponse> usedBookList = usedBookListService.getUsedBookList(canBuy);
+
+        //then
+        assertThat(usedBookList).hasSize(2);
+        assertThat(usedBookList.get(0).imageUrl()).isEqualTo(imageUrl);
+        assertThat(usedBookList.get(1).imageUrl()).isEqualTo(imageUrl);
+    }
+
+    private UsedBook createBook() {
+        return UsedBook.builder()
+                .name("book")
+                .price(10000)
+                .bookStatus(BookStatus.SALE)
+                .tradeAvailableDate(LocalDate.now())
+                .buyerMember(Member.builder().build())
+                .build();
+    }
+
+
+
+}

--- a/src/test/java/team/dankookie/server4983/config/TestConfig.java
+++ b/src/test/java/team/dankookie/server4983/config/TestConfig.java
@@ -1,0 +1,20 @@
+package team.dankookie.server4983.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class TestConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(){
+        return new JPAQueryFactory(entityManager);
+    }
+
+}


### PR DESCRIPTION
## ✔ 지라 이슈 번호
DAN-20

## 📒 작업 내용
- 기본적으로 중고서적의 리스트 api 구현 (판매중, 거래중, 거래완료 순으로 보여주고, 각각 마다 최신순으로)
- 단과대, 학과별로의 리스트 api 구현 (로직 위와 동일)
- entity 컬럼 enum으로 수정
- testConfig 추가

## 📢 리뷰어에게 하고 싶은 말
ex) 어디어디를 중점적으로 봐주세요 ...
QueryDsl 부분 위주로 봐주세요!

## 📌 PR 전 체크 사항
- [x] base 브랜치가 **develop** 또는 **main** 브랜치로 되어있나요?
- [x] PR title에 PR Type을 표시해 두었나요? (feat:, fix:, refact: ...)
- [x] test가 모두 통과 되었나요? 