### PR TITLE
feat: 스프링 시큐리티 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,8 +28,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
-//    db
+//    db (h2, mysql)
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
 
@@ -43,14 +44,20 @@ dependencies {
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
+//    Spring Security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 
+
+//     lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+
+//    spring-boot-configuration-processor
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
+//    spring-boot-devtools
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
 ext {

--- a/src/main/java/team/dankookie/server4983/common/config/PasswordEncoderConfiguration.java
+++ b/src/main/java/team/dankookie/server4983/common/config/PasswordEncoderConfiguration.java
@@ -1,0 +1,15 @@
+package team.dankookie.server4983.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfiguration {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/team/dankookie/server4983/common/config/SpringSecurityConfiguration.java
+++ b/src/main/java/team/dankookie/server4983/common/config/SpringSecurityConfiguration.java
@@ -1,0 +1,36 @@
+package team.dankookie.server4983.common.config;
+
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import team.dankookie.server4983.common.exception.CustomAuthenticationEntryPoint;
+
+//FIXME : authorizeHttpRequest 추후 수정 필요
+//FIXME : addFilterBefore JWT 부분 추후 수정 필요
+@Configuration
+@EnableWebSecurity
+public class SpringSecurityConfiguration {
+
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests((req) -> req
+                        .anyRequest().permitAll())
+                .sessionManagement((session) -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling((exception) -> exception
+                        .authenticationEntryPoint(new CustomAuthenticationEntryPoint()))
+//                .addFilterBefore(new JwtTokenFilter(userService, secretKey), UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+
+    
+}

--- a/src/main/java/team/dankookie/server4983/common/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/team/dankookie/server4983/common/exception/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,18 @@
+package team.dankookie.server4983.common.exception;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import java.io.IOException;
+
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        response.setContentType("application/json");
+        response.setStatus(ErrorCode.INVALID_TOKEN.getStatus().value());
+        response.getWriter().write(ErrorCode.INVALID_TOKEN.getMessage());
+    }
+}

--- a/src/main/java/team/dankookie/server4983/common/exception/ErrorCode.java
+++ b/src/main/java/team/dankookie/server4983/common/exception/ErrorCode.java
@@ -1,0 +1,18 @@
+package team.dankookie.server4983.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.*;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    INVALID_TOKEN(UNAUTHORIZED, "잘못된 토큰입니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+
+}


### PR DESCRIPTION
## ✔ 지라 이슈 번호
DAN-29

## 📒 작업 내용
- Spring Security 설정
- passwordEncoder DI 
- custom 인증인가 예외처리 구현 

## 📢 리뷰어에게 하고 싶은 말
원래 spring security를 안쓸려고 했는데, 
이유는 security userService 구현 부분이 되게 복잡하고 어렵다고 생각했고 복잡하다고 생각했는데, 
security userService는 form, basic 에 적용되는 부분이라서 우리랑 상관없고, 
간단하게 security는 passwordEncoder와 url 별 접근만 제어하게 설정하면 좋을 것같아서 추가하였습니다! 


## 📌 PR 전 체크 사항
- [x] base 브랜치가 **develop** 또는 **main** 브랜치로 되어있나요?
- [x] PR title에 PR Type을 표시해 두었나요? (feat:, fix:, refact: ...)
- [x] test가 모두 통과 되었나요? 