### PR TITLE
feat: 로그인 API 구현

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -9,6 +9,10 @@
 
 * link:https://github.com/dankookie-4983/4983-server[GitHub 주소]
 
-== User 문서
+== UsedBook 문서
 
 * link:usedBook.html[UsedBook 문서]
+
+== Member 문서
+
+* link:member.html[Member 문서]

--- a/src/docs/asciidoc/member.adoc
+++ b/src/docs/asciidoc/member.adoc
@@ -1,0 +1,48 @@
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+
+== 메인 문서
+
+link:index.html[메인 문서]
+
+=== 로그인, 회원가입 관련 api 문서
+
+==== 로그인 (성공)
+
+===== Request
+
+include::{snippets}/member/login/success/http-request.adoc[]
+include::{snippets}/member/login/success/request-fields.adoc[]
+
+===== Response
+
+include::{snippets}/member/login/success/http-response.adoc[]
+Cookie
+include::{snippets}/member/login/success/response-cookies.adoc[]
+Response Header
+include::{snippets}/member/login/success/response-headers.adoc[]
+
+==== 로그인 (학번 일치 안하는 경우)
+
+===== Request
+
+include::{snippets}/member/login/fail/studentId/http-request.adoc[]
+
+===== Response
+
+include::{snippets}/member/login/fail/studentId/http-response.adoc[]
+include::{snippets}/member/login/fail/studentId/response-fields.adoc[]
+
+==== 로그인 (비밀번호 일치 안하는 경우)
+
+===== Request
+
+include::{snippets}/member/login/fail/password/http-request.adoc[]
+
+===== Response
+
+include::{snippets}/member/login/fail/password/http-response.adoc[]
+include::{snippets}/member/login/fail/password/response-fields.adoc[]

--- a/src/main/java/team/dankookie/server4983/common/exception/ControllerExceptionAdvice.java
+++ b/src/main/java/team/dankookie/server4983/common/exception/ControllerExceptionAdvice.java
@@ -1,0 +1,16 @@
+package team.dankookie.server4983.common.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ControllerExceptionAdvice {
+
+    @ExceptionHandler(LoginFailedException.class)
+    public ResponseEntity<ErrorResponse> loginFailedException(LoginFailedException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ErrorResponse.of(e.getMessage()));
+    }
+
+}

--- a/src/main/java/team/dankookie/server4983/common/exception/ErrorResponse.java
+++ b/src/main/java/team/dankookie/server4983/common/exception/ErrorResponse.java
@@ -1,0 +1,18 @@
+package team.dankookie.server4983.common.exception;
+
+import lombok.Getter;
+
+
+@Getter
+public class ErrorResponse {
+
+    private final String message;
+
+    private ErrorResponse(String message) {
+        this.message = message;
+    }
+
+    public static ErrorResponse of(String message) {
+        return new ErrorResponse(message);
+    }
+}

--- a/src/main/java/team/dankookie/server4983/common/exception/LoginFailedException.java
+++ b/src/main/java/team/dankookie/server4983/common/exception/LoginFailedException.java
@@ -1,0 +1,12 @@
+package team.dankookie.server4983.common.exception;
+
+public class LoginFailedException extends RuntimeException {
+
+    public LoginFailedException() {
+        super("로그인에 실패하였습니다.");
+    }
+
+    public LoginFailedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/team/dankookie/server4983/member/controller/MemberLoginController.java
+++ b/src/main/java/team/dankookie/server4983/member/controller/MemberLoginController.java
@@ -1,0 +1,47 @@
+package team.dankookie.server4983.member.controller;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import team.dankookie.server4983.jwt.util.JwtTokenUtils;
+import team.dankookie.server4983.member.dto.LoginRequest;
+import team.dankookie.server4983.member.service.MemberService;
+
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+import static team.dankookie.server4983.jwt.constants.TokenDuration.ACCESS_TOKEN_DURATION;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1")
+public class MemberLoginController {
+
+    private final MemberService memberService;
+
+    @Value("${jwt.secret-key}")
+    private String secretKey;
+
+    @PostMapping("/login")
+    public ResponseEntity<Void> login(HttpServletResponse response, @RequestBody LoginRequest loginRequest) {
+        boolean isMemberExists = memberService.login(loginRequest);
+
+        if (isMemberExists) {
+            String nickname = memberService.findMemberNicknameByStudentId(loginRequest.studentId());
+
+            response.setHeader(HttpHeaders.AUTHORIZATION, JwtTokenUtils.generateAccessToken(nickname, secretKey, ACCESS_TOKEN_DURATION.getDuration()));
+
+            Cookie refreshTokenCookie = new Cookie("refreshToken", "refreshToken");
+            response.addCookie(refreshTokenCookie);
+
+            return ResponseEntity.ok().build();
+        } else {
+            return ResponseEntity.status(UNAUTHORIZED).build();
+        }
+    }
+}

--- a/src/main/java/team/dankookie/server4983/member/dto/LoginRequest.java
+++ b/src/main/java/team/dankookie/server4983/member/dto/LoginRequest.java
@@ -1,0 +1,10 @@
+package team.dankookie.server4983.member.dto;
+
+public record LoginRequest(
+        String studentId,
+        String password
+) {
+    public static LoginRequest of(String studentId, String password) {
+        return new LoginRequest(studentId, password);
+    }
+}

--- a/src/main/java/team/dankookie/server4983/member/repository/MemberRepository.java
+++ b/src/main/java/team/dankookie/server4983/member/repository/MemberRepository.java
@@ -7,4 +7,7 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByNickname(String nickname);
+    Optional<Member> findByStudentId(String studentId);
+
+
 }

--- a/src/main/java/team/dankookie/server4983/member/service/MemberService.java
+++ b/src/main/java/team/dankookie/server4983/member/service/MemberService.java
@@ -1,10 +1,11 @@
 package team.dankookie.server4983.member.service;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import team.dankookie.server4983.common.exception.LoginFailedException;
 import team.dankookie.server4983.member.domain.Member;
+import team.dankookie.server4983.member.dto.LoginRequest;
 import team.dankookie.server4983.member.repository.MemberRepository;
 
 @RequiredArgsConstructor
@@ -19,4 +20,22 @@ public class MemberService {
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
 
     }
+
+    public boolean login(LoginRequest loginRequest) {
+
+        Member member = memberRepository.findByStudentId(loginRequest.studentId())
+                .orElseThrow(() -> new LoginFailedException("존재하지 않는 학번입니다."));
+
+        if (!passwordEncoder.matches(loginRequest.password(), member.getPassword())) {
+            throw new LoginFailedException("잘못된 비밀번호입니다!");
+        }
+        return true;
+    }
+
+    public String findMemberNicknameByStudentId(String studentId) {
+        Member member = memberRepository.findByStudentId(studentId)
+                .orElseThrow(() -> new LoginFailedException("존재하지 않는 학번입니다."));
+        return member.getNickname();
+    }
+
 }

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -448,7 +448,8 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div id="toctitle">Table of Contents</div>
 <ul class="sectlevel1">
 <li><a href="#_github_주소">GitHub 주소</a></li>
-<li><a href="#_user_문서">User 문서</a></li>
+<li><a href="#_usedbook_문서">UsedBook 문서</a></li>
+<li><a href="#_member_문서">Member 문서</a></li>
 </ul>
 </div>
 </div>
@@ -466,7 +467,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </div>
 </div>
 <div class="sect1">
-<h2 id="_user_문서">User 문서</h2>
+<h2 id="_usedbook_문서">UsedBook 문서</h2>
 <div class="sectionbody">
 <div class="ulist">
 <ul>
@@ -477,11 +478,23 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </div>
 </div>
 </div>
+<div class="sect1">
+<h2 id="_member_문서">Member 문서</h2>
+<div class="sectionbody">
+<div class="ulist">
+<ul>
+<li>
+<p><a href="member.html">Member 문서</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
 </div>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-08-28 21:11:42 +0900
+Last updated 2023-08-30 18:18:34 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/main/resources/static/docs/member.html
+++ b/src/main/resources/static/docs/member.html
@@ -443,11 +443,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div id="toc" class="toc2">
 <div id="toctitle">Table of Contents</div>
 <ul class="sectlevel1">
-<li><a href="#_메인_문서">메인 문서</a></li>
-<li><a href="#_usedbook_메인페이지_관련_문서">UsedBook 메인페이지 관련 문서</a>
+<li><a href="#_메인_문서">메인 문서</a>
 <ul class="sectlevel2">
-<li><a href="#_조건없는_책_리스트_가져오기_판매중_거래중_판매완료_순으로_보이고_각각_날짜에_따라_최신순으로_정렬">조건없는 책 리스트 가져오기 (판매중, 거래중, 판매완료 순으로 보이고 각각 날짜에 따라 최신순으로 정렬)</a></li>
-<li><a href="#_단과대_학과에_따라_서적_리스트_가져오기">단과대 학과에 따라 서적 리스트 가져오기</a></li>
+<li><a href="#_로그인_회원가입_관련_api_문서">로그인, 회원가입 관련 api 문서</a></li>
 </ul>
 </li>
 </ul>
@@ -460,31 +458,20 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div class="paragraph">
 <p><a href="index.html">메인 문서</a></p>
 </div>
-</div>
-</div>
-<div class="sect1">
-<h2 id="_usedbook_메인페이지_관련_문서">UsedBook 메인페이지 관련 문서</h2>
-<div class="sectionbody">
 <div class="sect2">
-<h3 id="_조건없는_책_리스트_가져오기_판매중_거래중_판매완료_순으로_보이고_각각_날짜에_따라_최신순으로_정렬">조건없는 책 리스트 가져오기 (판매중, 거래중, 판매완료 순으로 보이고 각각 날짜에 따라 최신순으로 정렬)</h3>
+<h3 id="_로그인_회원가입_관련_api_문서">로그인, 회원가입 관련 api 문서</h3>
 <div class="sect3">
-<h4 id="_request">Request</h4>
+<h4 id="_로그인_성공">로그인 (성공)</h4>
+<div class="sect4">
+<h5 id="_request">Request</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/used-book-list?canBuyElseAll=false HTTP/1.1
-Host: localhost:8080</code></pre>
-</div>
-</div>
-</div>
-<div class="sect3">
-<h4 id="_response">Response</h4>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/login HTTP/1.1
 Content-Type: application/json
-Content-Length: 307
+Content-Length: 47
+Host: localhost:8080
 
-[{"imageUrl":"imageUrl","bookStatus":"SALE","name":"책이름","tradeAvailableDate":"2023-08-30","createdAt":"2023-08-30T18:26:08.734524","price":10000},{"imageUrl":"imageUrl","bookStatus":"TRADE","name":"책이름","tradeAvailableDate":"2023-08-30","createdAt":"2023-08-30T18:26:08.734535","price":100000}]</code></pre>
+{"studentId":"studentId","password":"password"}</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
@@ -502,91 +489,95 @@ Content-Length: 307
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].imageUrl</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>studentId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">책 이미지</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이메일</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].bookStatus</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>password</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">책 상태</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].name</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">책 이름</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].tradeAvailableDate</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">거래 가능 날짜</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].createdAt</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">책 등록 날짜</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].price</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">책 가격</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">비밀번호</p></td>
 </tr>
 </tbody>
 </table>
 </div>
-</div>
-<div class="sect2">
-<h3 id="_단과대_학과에_따라_서적_리스트_가져오기">단과대 학과에 따라 서적 리스트 가져오기</h3>
-<div class="sect3">
-<h4 id="_request_2">Request</h4>
+<div class="sect4">
+<h5 id="_response">Response</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/used-book-list/college-and-department?college=ENGINEERING%2CEDUCATION&amp;department=COMPUTER%2CSOFTWARE%2CKOREAN&amp;canBuyElseAll=false HTTP/1.1
-Host: localhost:8080</code></pre>
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Authorization: eyJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2OTMzODc1NjksImV4cCI6MTY5MzM4OTM2OX0.etf-iC5mAnxhcjE7_DfHNrahC5sVk-HkGGZxqIipPtc
+Set-Cookie: refreshToken=refreshToken</code></pre>
 </div>
 </div>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Parameter</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>college</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">단과대학 enum 리스트</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>department</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">학과 enum 리스트</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>canBuyElseAll</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">구매 가능 여부</p></td>
-</tr>
-</tbody>
-</table>
-<div class="sect4">
-<h5 id="_queryparameter_예시">QueryParameter 예시</h5>
 <div class="paragraph">
-<p>api?college=ENGINEERING,EDUCATION&amp;department=COMPUTER,SOFTWARE,KOREAN</p>
+<p>Cookie</p>
 </div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>refreshToken</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">refreshToken</p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>Response Header</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
+</tr>
+</tbody>
+</table>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_2">Response</h4>
+<h4 id="_로그인_학번_일치_안하는_경우">로그인 (학번 일치 안하는 경우)</h4>
+<div class="sect4">
+<h5 id="_request_2">Request</h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/login HTTP/1.1
 Content-Type: application/json
-Content-Length: 307
+Content-Length: 47
+Host: localhost:8080
 
-[{"imageUrl":"imageUrl","bookStatus":"SALE","name":"책이름","tradeAvailableDate":"2023-08-30","createdAt":"2023-08-30T18:26:08.814872","price":10000},{"imageUrl":"imageUrl","bookStatus":"TRADE","name":"책이름","tradeAvailableDate":"2023-08-30","createdAt":"2023-08-30T18:26:08.814877","price":100000}]</code></pre>
+{"studentId":"studentId","password":"password"}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_response_2">Response</h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 401 Unauthorized
+Content-Type: application/json
+Content-Length: 50
+
+{"message":"존재하지 않는 학번입니다."}</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
@@ -604,131 +595,61 @@ Content-Length: 307
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].imageUrl</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">책 이미지</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].bookStatus</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">책 상태</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].name</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">책 이름</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].tradeAvailableDate</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">거래 가능 날짜</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].createdAt</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">책 등록 날짜</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].price</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">책 가격</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">에러 메시지</p></td>
 </tr>
 </tbody>
 </table>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_로그인_비밀번호_일치_안하는_경우">로그인 (비밀번호 일치 안하는 경우)</h4>
 <div class="sect4">
-<h5 id="_college_enum_앞의_영어만_보면됨">College Enum (앞의 영어만 보면됨)</h5>
-<div class="literalblock">
+<h5 id="_request_3">Request</h5>
+<div class="listingblock">
 <div class="content">
-<pre>BUSINESS_AND_ECONOMICS("경영경제대학" ),
-SW_CONVERGENCE("SW융합대학"),
-SOCIAL_SCIENCES("사회과학대학"),
-LITERAL_ARTS("문과대학"),
-LAW("법과대학"),
-ENGINEERING("공과대학"),
-EDUCATION("사범대학"),
-MUSIC_AND_ARTS("음악예술대학");</pre>
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/login HTTP/1.1
+Content-Type: application/json
+Content-Length: 47
+Host: localhost:8080
+
+{"studentId":"studentId","password":"password"}</code></pre>
 </div>
 </div>
 </div>
 <div class="sect4">
-<h5 id="_department_enum_앞에_영어만_보면됨">Department Enum (앞에 영어만 보면됨)</h5>
-<div class="literalblock">
+<h5 id="_response_3">Response</h5>
+<div class="listingblock">
 <div class="content">
-<pre>BUSINESS("경영학과", BUSINESS_AND_ECONOMICS),
-ECONOMICS("경제학과", BUSINESS_AND_ECONOMICS),
-INTERNATIONAL_BUSINESS("국제경영학전공", BUSINESS_AND_ECONOMICS),
-TRADE("무역학과", BUSINESS_AND_ECONOMICS),
-INDUSTRIAL_BUSINESS("산업경영학과", BUSINESS_AND_ECONOMICS),
-ACCOUNTING("회계학과", BUSINESS_AND_ECONOMICS),</pre>
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 401 Unauthorized
+Content-Type: application/json
+Content-Length: 46
+
+{"message":"잘못된 비밀번호입니다!"}</code></pre>
 </div>
 </div>
-<div class="literalblock">
-<div class="content">
-<pre>POLITICAL("정치외교학과", SOCIAL_SCIENCES),
-PUBLIC_ADMINISTRATION("행정학과", SOCIAL_SCIENCES),
-URBAN_PLANNING("도시계획부동산학부", SOCIAL_SCIENCES),
-MEDIA_COMMUNICATION("미디어커뮤니케이션학부", SOCIAL_SCIENCES),
-CONSULTING("상담학과", SOCIAL_SCIENCES),</pre>
-</div>
-</div>
-<div class="literalblock">
-<div class="content">
-<pre>DEPARTMENT_OF_LAW("법학과", LAW),</pre>
-</div>
-</div>
-<div class="literalblock">
-<div class="content">
-<pre>KOREAN("국어국문과", LITERAL_ARTS),
-HISTORY("사학과", LITERAL_ARTS),
-PHILOSOPHY("철학과", LITERAL_ARTS),
-AMERICAN_HUMANITY("영미인문학과", LITERAL_ARTS),</pre>
-</div>
-</div>
-<div class="literalblock">
-<div class="content">
-<pre>ELECTRICAL("전자전기공학전공", ENGINEERING),
-POLYMER("고분자공학전공", ENGINEERING),
-FUSION_SEMICONDUCTOR("융합반도체공학전공", ENGINEERING),
-FIBER("파이버융합소재공학전공", ENGINEERING),
-CHEMICAL("화학공학과", ENGINEERING),
-ARCHITECTURE_ENGINEER("건축공학전공", ENGINEERING),
-ARCHITECTURE("건축학전공", ENGINEERING),</pre>
-</div>
-</div>
-<div class="literalblock">
-<div class="content">
-<pre>SOFTWARE("소프트웨어학과", SW_CONVERGENCE),
-COMPUTER("컴퓨터공학과", SW_CONVERGENCE),
-MOBILE_SYSTEM("모바일시스템공학과", SW_CONVERGENCE),
-STATISTICS("정보통계학과", SW_CONVERGENCE),
-SECURITY("산업보안학과", SW_CONVERGENCE),</pre>
-</div>
-</div>
-<div class="literalblock">
-<div class="content">
-<pre>MATH("수학교육과", EDUCATION),
-SCIENCE("과학교육과", EDUCATION),
-ATHLETIC("체육교육과", EDUCATION),
-CHINESE("한문교육과", EDUCATION),
-SPECIAL("특수교육과", EDUCATION),</pre>
-</div>
-</div>
-<div class="literalblock">
-<div class="content">
-<pre>MOVIE("영화전공", MUSIC_AND_ARTS),
-THEATER("연극전공", MUSIC_AND_ARTS),
-MUSICAL("뮤지컬전공", MUSIC_AND_ARTS),
-CERAMICS("도예과", MUSIC_AND_ARTS),
-COMMUNICATION_DESIGN("커뮤니케이션디자인전공", MUSIC_AND_ARTS),
-INDUSTRIAL_DESIGN("패션산업디자인전공", MUSIC_AND_ARTS),
-DANCING("무용과", MUSIC_AND_ARTS),
-PIANO("피아노전공", MUSIC_AND_ARTS),
-VOCAL("성악전공", MUSIC_AND_ARTS),
-ORCHESTRA("관현악전공", MUSIC_AND_ARTS),
-COMPOSITION("작곡전공", MUSIC_AND_ARTS),
-GUGAK("국악전공", MUSIC_AND_ARTS);</pre>
-</div>
-</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">에러 메시지</p></td>
+</tr>
+</tbody>
+</table>
 </div>
 </div>
 </div>
@@ -738,7 +659,7 @@ GUGAK("국악전공", MUSIC_AND_ARTS);</pre>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-08-28 22:22:16 +0900
+Last updated 2023-08-30 18:26:02 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/test/java/team/dankookie/server4983/book/controller/UsedBookListControllerTest.java
+++ b/src/test/java/team/dankookie/server4983/book/controller/UsedBookListControllerTest.java
@@ -1,29 +1,14 @@
 package team.dankookie.server4983.book.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayNameGeneration;
-import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
-import org.springframework.restdocs.RestDocumentationContextProvider;
-import org.springframework.restdocs.RestDocumentationExtension;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.test.context.web.WebAppConfiguration;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.context.WebApplicationContext;
 import team.dankookie.server4983.book.constant.BookStatus;
 import team.dankookie.server4983.book.constant.College;
 import team.dankookie.server4983.book.constant.Department;
 import team.dankookie.server4983.book.dto.UsedBookListResponse;
 import team.dankookie.server4983.book.service.UsedBookListService;
+import team.dankookie.server4983.common.BaseControllerTest;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -31,7 +16,6 @@ import java.util.List;
 
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
@@ -40,30 +24,10 @@ import static org.springframework.restdocs.request.RequestDocumentation.queryPar
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SuppressWarnings("NonAsciiCharacters")
-@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-@SpringBootTest
-@AutoConfigureRestDocs
-@ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
-@MockBean(JpaMetamodelMappingContext.class)
-@WebAppConfiguration
-class UsedBookListControllerTest {
-
-    MockMvc mockMvc;
-
-    @Autowired
-    ObjectMapper objectMapper;
+class UsedBookListControllerTest extends BaseControllerTest {
 
     @MockBean
-    UsedBookListService usedBookListService;
-
-    @BeforeEach
-    public void init(WebApplicationContext webApplicationContext,
-                     RestDocumentationContextProvider restDocumentation) {
-        this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
-                .apply(documentationConfiguration(restDocumentation))
-                .build();
-    }
+    private UsedBookListService usedBookListService;
 
     final String API = "/api/used-book-list";
 

--- a/src/test/java/team/dankookie/server4983/book/repository/usedBook/UsedBookRepositoryTest.java
+++ b/src/test/java/team/dankookie/server4983/book/repository/usedBook/UsedBookRepositoryTest.java
@@ -1,18 +1,13 @@
 package team.dankookie.server4983.book.repository.usedBook;
 
 
-import org.junit.jupiter.api.DisplayNameGeneration;
-import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
 import team.dankookie.server4983.book.constant.BookStatus;
 import team.dankookie.server4983.book.constant.College;
 import team.dankookie.server4983.book.constant.Department;
 import team.dankookie.server4983.book.domain.UsedBook;
 import team.dankookie.server4983.common.BaseRepositoryTest;
-import team.dankookie.server4983.config.TestConfig;
 import team.dankookie.server4983.member.constant.AccountBank;
 import team.dankookie.server4983.member.domain.Member;
 import team.dankookie.server4983.member.repository.MemberRepository;

--- a/src/test/java/team/dankookie/server4983/book/repository/usedBook/UsedBookRepositoryTest.java
+++ b/src/test/java/team/dankookie/server4983/book/repository/usedBook/UsedBookRepositoryTest.java
@@ -11,6 +11,7 @@ import team.dankookie.server4983.book.constant.BookStatus;
 import team.dankookie.server4983.book.constant.College;
 import team.dankookie.server4983.book.constant.Department;
 import team.dankookie.server4983.book.domain.UsedBook;
+import team.dankookie.server4983.common.BaseRepositoryTest;
 import team.dankookie.server4983.config.TestConfig;
 import team.dankookie.server4983.member.constant.AccountBank;
 import team.dankookie.server4983.member.domain.Member;
@@ -22,11 +23,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 
-@SuppressWarnings("NonAsciiCharacters")
-@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-@DataJpaTest
-@Import(TestConfig.class)
-class UsedBookRepositoryTest {
+class UsedBookRepositoryTest extends BaseRepositoryTest {
 
     @Autowired
     UsedBookRepository usedBookRepository;

--- a/src/test/java/team/dankookie/server4983/book/service/UsedBookListServiceTest.java
+++ b/src/test/java/team/dankookie/server4983/book/service/UsedBookListServiceTest.java
@@ -12,6 +12,7 @@ import team.dankookie.server4983.book.domain.UsedBook;
 import team.dankookie.server4983.book.dto.UsedBookListResponse;
 import team.dankookie.server4983.book.repository.bookImage.BookImageRepository;
 import team.dankookie.server4983.book.repository.usedBook.UsedBookRepository;
+import team.dankookie.server4983.common.BaseServiceTest;
 import team.dankookie.server4983.member.domain.Member;
 
 import java.time.LocalDate;
@@ -21,10 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-@SuppressWarnings("NonAsciiCharacters")
-@DisplayNameGeneration(ReplaceUnderscores.class)
-@ExtendWith(MockitoExtension.class)
-class UsedBookListServiceTest {
+class UsedBookListServiceTest extends BaseServiceTest {
 
     @InjectMocks
     UsedBookListService usedBookListService;

--- a/src/test/java/team/dankookie/server4983/common/BaseControllerTest.java
+++ b/src/test/java/team/dankookie/server4983/common/BaseControllerTest.java
@@ -1,0 +1,46 @@
+package team.dankookie.server4983.common;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+
+
+@SpringBootTest
+@AutoConfigureRestDocs
+@ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
+@MockBean(JpaMetamodelMappingContext.class)
+@WebAppConfiguration
+public abstract class BaseControllerTest extends BaseDisplayNameConfig {
+
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    protected final String API = "/api/v1";
+
+    @BeforeEach
+    public void init(WebApplicationContext webApplicationContext,
+                     RestDocumentationContextProvider restDocumentation) {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+                .apply(documentationConfiguration(restDocumentation))
+                .build();
+    }
+
+}

--- a/src/test/java/team/dankookie/server4983/common/BaseDisplayNameConfig.java
+++ b/src/test/java/team/dankookie/server4983/common/BaseDisplayNameConfig.java
@@ -1,0 +1,9 @@
+package team.dankookie.server4983.common;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public abstract class BaseDisplayNameConfig {
+}

--- a/src/test/java/team/dankookie/server4983/common/BaseRepositoryTest.java
+++ b/src/test/java/team/dankookie/server4983/common/BaseRepositoryTest.java
@@ -1,0 +1,12 @@
+package team.dankookie.server4983.common;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import team.dankookie.server4983.config.TestConfig;
+
+@DataJpaTest
+@Import(TestConfig.class)
+public class BaseRepositoryTest extends BaseDisplayNameConfig {
+}

--- a/src/test/java/team/dankookie/server4983/common/BaseServiceTest.java
+++ b/src/test/java/team/dankookie/server4983/common/BaseServiceTest.java
@@ -1,0 +1,10 @@
+package team.dankookie.server4983.common;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public abstract class BaseServiceTest extends BaseDisplayNameConfig {
+}

--- a/src/test/java/team/dankookie/server4983/member/controller/MemberLoginControllerTest.java
+++ b/src/test/java/team/dankookie/server4983/member/controller/MemberLoginControllerTest.java
@@ -80,7 +80,7 @@ class MemberLoginControllerTest extends BaseControllerTest {
         //then
         resultActions.andExpect(status().isUnauthorized())
                 .andDo(
-                        document("member/login/success",
+                        document("member/login/fail/studentId",
                                 requestFields(
                                         fieldWithPath("studentId").description("이메일"),
                                         fieldWithPath("password").description("비밀번호")
@@ -112,7 +112,7 @@ class MemberLoginControllerTest extends BaseControllerTest {
         //then
         resultActions.andExpect(status().isUnauthorized())
                 .andDo(
-                        document("member/login/success",
+                        document("member/login/fail/password",
                                 requestFields(
                                         fieldWithPath("studentId").description("이메일"),
                                         fieldWithPath("password").description("비밀번호")

--- a/src/test/java/team/dankookie/server4983/member/controller/MemberLoginControllerTest.java
+++ b/src/test/java/team/dankookie/server4983/member/controller/MemberLoginControllerTest.java
@@ -1,0 +1,127 @@
+package team.dankookie.server4983.member.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.restdocs.cookies.CookieDocumentation;
+import org.springframework.restdocs.headers.HeaderDocumentation;
+import org.springframework.test.web.servlet.ResultActions;
+import team.dankookie.server4983.common.BaseControllerTest;
+import team.dankookie.server4983.common.exception.LoginFailedException;
+import team.dankookie.server4983.member.dto.LoginRequest;
+import team.dankookie.server4983.member.service.MemberService;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class MemberLoginControllerTest extends BaseControllerTest {
+
+    @MockBean
+    MemberService memberService;
+
+    @Test
+    void 로그인시_accessToken과_refreshToken을_리턴한다() throws Exception {
+        //given
+        String loginUrl = API + "/login";
+
+        LoginRequest loginRequest = LoginRequest.of("studentId", "password");
+
+
+        when(memberService.login(loginRequest))
+                .thenReturn(true);
+
+        //when
+        ResultActions resultActions = mockMvc.perform(post(loginUrl)
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(loginRequest))
+        ).andDo(print());
+
+        //then
+        resultActions.andExpect(status().isOk())
+                .andDo(
+                        document("member/login/success",
+                                requestFields(
+                                        fieldWithPath("studentId").description("이메일"),
+                                        fieldWithPath("password").description("비밀번호")
+                                ),
+                                CookieDocumentation.responseCookies(
+                                        CookieDocumentation.cookieWithName("refreshToken").description("refreshToken")
+                                ),
+                                HeaderDocumentation.responseHeaders(
+                                        headerWithName("Authorization").description("accessToken")
+
+                                )
+                        )
+                );
+    }
+
+    @Test
+    void 로그인시_학번이_없으면_에러를_던진다() throws Exception {
+        //given
+        String loginUrl = API + "/login";
+
+        LoginRequest loginRequest = LoginRequest.of("studentId", "password");
+
+
+        when(memberService.login(loginRequest))
+                .thenThrow(new LoginFailedException("존재하지 않는 학번입니다."));
+
+        //when
+        ResultActions resultActions = mockMvc.perform(post(loginUrl)
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(loginRequest))
+        ).andDo(print());
+
+        //then
+        resultActions.andExpect(status().isUnauthorized())
+                .andDo(
+                        document("member/login/success",
+                                requestFields(
+                                        fieldWithPath("studentId").description("이메일"),
+                                        fieldWithPath("password").description("비밀번호")
+                                ),
+                                responseFields(
+                                        fieldWithPath("message").description("에러 메시지")
+                                )
+                        )
+                );
+    }
+
+    @Test
+    void 로그인시_비밀번호가_일치하지_않으면_에러를_던진다() throws Exception {
+        //given
+        String loginUrl = API + "/login";
+
+        LoginRequest loginRequest = LoginRequest.of("studentId", "password");
+
+
+        when(memberService.login(loginRequest))
+                .thenThrow(new LoginFailedException("잘못된 비밀번호입니다!"));
+
+        //when
+        ResultActions resultActions = mockMvc.perform(post(loginUrl)
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(loginRequest))
+        ).andDo(print());
+
+        //then
+        resultActions.andExpect(status().isUnauthorized())
+                .andDo(
+                        document("member/login/success",
+                                requestFields(
+                                        fieldWithPath("studentId").description("이메일"),
+                                        fieldWithPath("password").description("비밀번호")
+                                ),
+                                responseFields(
+                                        fieldWithPath("message").description("에러 메시지")
+                                )
+                        )
+                );
+    }
+
+}

--- a/src/test/java/team/dankookie/server4983/member/fixture/MemberFixture.java
+++ b/src/test/java/team/dankookie/server4983/member/fixture/MemberFixture.java
@@ -1,0 +1,50 @@
+package team.dankookie.server4983.member.fixture;
+
+import team.dankookie.server4983.book.constant.Department;
+import team.dankookie.server4983.member.constant.AccountBank;
+import team.dankookie.server4983.member.domain.Member;
+
+public class MemberFixture {
+
+    public static final Member createMember() {
+        return Member.builder()
+                .accountBank(AccountBank.K)
+                .accountHolder("accountHolder")
+                .accountNumber("accountNumber")
+                .nickname("nickname")
+                .studentId("studentId")
+                .phoneNumber("phoneNumber")
+                .department(Department.DEPARTMENT_OF_LAW)
+                .yearOfAdmission(2023)
+                .password("password")
+                .build();
+    }
+
+    public static Member createMemberByNickname(String nickname) {
+        return Member.builder()
+                .accountBank(AccountBank.K)
+                .accountHolder("accountHolder")
+                .accountNumber("accountNumber")
+                .nickname(nickname)
+                .studentId("studentId")
+                .phoneNumber("phoneNumber")
+                .department(Department.DEPARTMENT_OF_LAW)
+                .yearOfAdmission(2023)
+                .password("password")
+                .build();
+    }
+
+    public static Member createMemberByStudentId(String studentId) {
+        return Member.builder()
+                .accountBank(AccountBank.K)
+                .accountHolder("accountHolder")
+                .accountNumber("accountNumber")
+                .nickname("nickname")
+                .studentId(studentId)
+                .phoneNumber("phoneNumber")
+                .department(Department.DEPARTMENT_OF_LAW)
+                .yearOfAdmission(2023)
+                .password("password")
+                .build();
+    }
+}

--- a/src/test/java/team/dankookie/server4983/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/team/dankookie/server4983/member/repository/MemberRepositoryTest.java
@@ -1,0 +1,48 @@
+package team.dankookie.server4983.member.repository;
+
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import team.dankookie.server4983.common.BaseRepositoryTest;
+import team.dankookie.server4983.member.domain.Member;
+import team.dankookie.server4983.member.fixture.MemberFixture;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MemberRepositoryTest extends BaseRepositoryTest {
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Test
+    void 사용자의_nickname으로_멤버를_찾는다() {
+        //given
+        final String nickname = "nickname";
+
+        Member member = MemberFixture.createMemberByNickname(nickname);
+        memberRepository.save(member);
+
+        //when
+        Optional<Member> findMember = memberRepository.findByNickname(nickname);
+
+        //then
+        assertThat(findMember).isPresent();
+    }
+
+    @Test
+    void 사용자의_학번으로_사용자를_찾는다() {
+        //given
+        final String studentId = "studentId";
+        Member member = MemberFixture.createMemberByStudentId(studentId);
+        memberRepository.save(member);
+
+        //when
+        Optional<Member> findMember = memberRepository.findByStudentId(studentId);
+
+        //then
+        assertThat(findMember).isPresent();
+    }
+
+}

--- a/src/test/java/team/dankookie/server4983/member/service/MemberServiceTest.java
+++ b/src/test/java/team/dankookie/server4983/member/service/MemberServiceTest.java
@@ -1,0 +1,115 @@
+package team.dankookie.server4983.member.service;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import team.dankookie.server4983.common.BaseServiceTest;
+import team.dankookie.server4983.common.exception.LoginFailedException;
+import team.dankookie.server4983.member.domain.Member;
+import team.dankookie.server4983.member.dto.LoginRequest;
+import team.dankookie.server4983.member.repository.MemberRepository;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+class MemberServiceTest extends BaseServiceTest {
+
+    @InjectMocks
+    MemberService memberService;
+
+    @Mock
+    MemberRepository memberRepository;
+
+    @Mock
+    PasswordEncoder passwordEncoder;
+    
+    @Test
+    void 유저의_학번과_비밀번호가_일치하면_true를_리턴한다() {
+        //given
+        LoginRequest loginRequest = LoginRequest.of("studentId", "password");
+
+        Member member = Member.builder().nickname("nickname").studentId("studentId").password("password").build();
+
+        when(memberRepository.findByStudentId(loginRequest.studentId()))
+                .thenReturn(Optional.of(member));
+
+        when(passwordEncoder.matches(loginRequest.password(), member.getPassword()))
+                .thenReturn(true);
+
+        //when
+        boolean login = memberService.login(loginRequest);
+
+        //then
+        assertThat(login).isEqualTo(true);
+    }
+
+    @Test
+    void 학번이_일치하지않는_경우_에러를_던진다() {
+        //given
+        LoginRequest loginRequest = LoginRequest.of("studentId", "password");
+
+        Member member = Member.builder().nickname("nickname").studentId("studentId").password("password").build();
+
+        when(memberRepository.findByStudentId(loginRequest.studentId()))
+                .thenReturn(Optional.empty());
+        //when
+        //then
+        assertThatThrownBy(() -> memberService.login(loginRequest))
+                .isInstanceOf(LoginFailedException.class);
+
+    }
+
+    @Test
+    void 학번은_존재하는데_비밀번호가_일치하지_않으면_에러를_던진다() {
+        //given
+        LoginRequest loginRequest = LoginRequest.of("studentId", "password");
+
+        Member member = Member.builder().nickname("nickname").studentId("studentId").password("password").build();
+
+        when(memberRepository.findByStudentId(loginRequest.studentId()))
+                .thenReturn(Optional.of(member));
+
+        when(passwordEncoder.matches(loginRequest.password(), member.getPassword()))
+                .thenReturn(false);
+        //when
+        //then
+        assertThatThrownBy(() -> memberService.login(loginRequest))
+                .isInstanceOf(LoginFailedException.class);
+
+    }
+
+    @Test
+    void 학번으로_유저의_닉네임을_알아낸다() {
+        //given
+        String studentId = "studentId";
+        Member member = Member.builder().nickname("nickname").build();
+
+        when(memberRepository.findByStudentId(studentId))
+                .thenReturn(Optional.of(member));
+        //when
+        String nickname = memberService.findMemberNicknameByStudentId(studentId);
+
+        //then
+        assertThat(nickname).isEqualTo(member.getNickname());
+    }
+
+    @Test
+    void 학번이_존재하지_않으면_에러를_던진다() {
+        //given
+        String studentId = "studentId";
+        Member member = Member.builder().nickname("nickname").build();
+
+        when(memberRepository.findByStudentId(studentId))
+                .thenReturn(Optional.empty());
+        //when
+        //then
+        assertThatThrownBy(() -> memberService.findMemberNicknameByStudentId(studentId))
+                .isInstanceOf(LoginFailedException.class);
+    }
+    
+
+}


### PR DESCRIPTION
## ✔ 지라 이슈 번호
DAN-31

## 📒 작업 내용
- 로그인 API 구현 
- 테스트시 마다 어노테이션 작성에 불편함을 겪어서 공통 클래스로 생성
- 멤버 생성해주는 클래스 생성( 보통 fixture 패키지에 작성)
- RestControllerAdvice 추가 

## 📢 리뷰어에게 하고 싶은 말
지난번 해요랑 다르게 controller에 response 및 Header 로직을 추가하였는데, 
tdd를 해보니 외부에서 cookie나 header를 넣어주고 테스트하기 어려운데,
controller 단에서 처리하는게 맞다고 생각되어서 이번에 이렇게 작성했습니다!

## 📌 PR 전 체크 사항
- [x] base 브랜치가 **develop** 또는 **main** 브랜치로 되어있나요?
- [x] PR title에 PR Type을 표시해 두었나요? (feat:, fix:, refact: ...)
- [x] test가 모두 통과 되었나요? 