### PR TITLE
feat: 비밀번호 재설정 및 비밀번호 변경시 인증번호 로직 추가 

### DIFF
--- a/src/docs/asciidoc/member.adoc
+++ b/src/docs/asciidoc/member.adoc
@@ -8,16 +8,15 @@
 
 link:index.html[메인 문서]
 
-=== 로그인, 회원가입 관련 api 문서
 
-==== 로그인 (성공)
+=== 로그인 (성공)
 
-===== Request
+==== Request
 
 include::{snippets}/member/login/success/http-request.adoc[]
 include::{snippets}/member/login/success/request-fields.adoc[]
 
-===== Response
+==== Response
 
 include::{snippets}/member/login/success/http-response.adoc[]
 Cookie
@@ -25,24 +24,100 @@ include::{snippets}/member/login/success/response-cookies.adoc[]
 Response Header
 include::{snippets}/member/login/success/response-headers.adoc[]
 
-==== 로그인 (학번 일치 안하는 경우)
+=== 로그인 (학번 일치 안하는 경우)
 
-===== Request
+==== Request
 
 include::{snippets}/member/login/fail/studentId/http-request.adoc[]
 
-===== Response
+==== Response
 
 include::{snippets}/member/login/fail/studentId/http-response.adoc[]
 include::{snippets}/member/login/fail/studentId/response-fields.adoc[]
 
-==== 로그인 (비밀번호 일치 안하는 경우)
+=== 로그인 (비밀번호 일치 안하는 경우)
 
-===== Request
+==== Request
 
 include::{snippets}/member/login/fail/password/http-request.adoc[]
 
-===== Response
+==== Response
 
 include::{snippets}/member/login/fail/password/http-response.adoc[]
 include::{snippets}/member/login/fail/password/response-fields.adoc[]
+
+=== 비밀번호 인증번호 보내기 (성공)
+
+==== Request
+
+include::{snippets}/member/password/certification-number/success/http-request.adoc[]
+
+===== query parameters
+include::{snippets}/member/password/certification-number/success/query-parameters.adoc[]
+
+==== Response
+
+include::{snippets}/member/password/certification-number/success/http-response.adoc[]
+include::{snippets}/member/password/certification-number/success/response-fields.adoc[]
+
+=== 비밀번호 인증번호 보내기 (실패 : 학번 일치하지 않는 경우)
+
+==== Request
+
+include::{snippets}/member/password/certification-number/fail/studentId/http-request.adoc[]
+===== query parameters
+include::{snippets}/member/password/certification-number/fail/studentId/query-parameters.adoc[]
+
+==== Response
+
+include::{snippets}/member/password/certification-number/fail/studentId/http-response.adoc[]
+include::{snippets}/member/password/certification-number/fail/studentId/response-fields.adoc[]
+
+
+=== 비밀번호 인증번호 보내기 (실패: 휴대폰번호와 일치하지 않는 경우)
+
+==== Request
+
+include::{snippets}/member/password/certification-number/fail/phoneNumber/http-request.adoc[]
+===== query parameters
+include::{snippets}/member/password/certification-number/fail/phoneNumber/query-parameters.adoc[]
+
+==== Response
+
+include::{snippets}/member/password/certification-number/fail/phoneNumber/http-response.adoc[]
+include::{snippets}/member/password/certification-number/fail/phoneNumber/response-fields.adoc[]
+
+=== 비밀번호 변경 (성공)
+
+==== Request
+
+include::{snippets}/member/password/change/success/http-request.adoc[]
+include::{snippets}/member/password/change/success/request-fields.adoc[]
+
+==== Response
+
+include::{snippets}/member/password/change/success/http-response.adoc[]
+
+=== 비밀번호 변경 (실패: 학번이 존재하지 않는 경우)
+
+==== Request
+
+include::{snippets}/member/password/change/fail/studentId/http-request.adoc[]
+include::{snippets}/member/password/change/fail/studentId/request-fields.adoc[]
+
+==== Response
+
+include::{snippets}/member/password/change/fail/studentId/http-response.adoc[]
+include::{snippets}/member/password/change/fail/studentId/response-fields.adoc[]
+
+=== 비밀번호 변경 (실패: 휴대폰번호가 학번과 일치하지 않는 경우)
+
+==== Request
+
+include::{snippets}/member/password/change/fail/phoneNumber/http-request.adoc[]
+include::{snippets}/member/password/change/fail/phoneNumber/request-fields.adoc[]
+
+==== Response
+
+include::{snippets}/member/password/change/fail/phoneNumber/http-response.adoc[]
+include::{snippets}/member/password/change/fail/phoneNumber/response-fields.adoc[]

--- a/src/main/java/team/dankookie/server4983/common/exception/ControllerExceptionAdvice.java
+++ b/src/main/java/team/dankookie/server4983/common/exception/ControllerExceptionAdvice.java
@@ -13,4 +13,8 @@ public class ControllerExceptionAdvice {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ErrorResponse.of(e.getMessage()));
     }
 
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> illegalArgumentException(IllegalArgumentException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ErrorResponse.of(e.getMessage()));
+    }
 }

--- a/src/main/java/team/dankookie/server4983/member/controller/MemberPasswordController.java
+++ b/src/main/java/team/dankookie/server4983/member/controller/MemberPasswordController.java
@@ -1,0 +1,37 @@
+package team.dankookie.server4983.member.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import team.dankookie.server4983.member.dto.MemberPasswordChangeRequest;
+import team.dankookie.server4983.member.service.MemberService;
+import team.dankookie.server4983.sms.dto.SmsCertificationNumber;
+import team.dankookie.server4983.sms.service.SmsService;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/members")
+public class MemberPasswordController {
+
+    private final MemberService memberService;
+    private final SmsService smsService;
+
+    @GetMapping("/password/certification-number")
+    public ResponseEntity<SmsCertificationNumber> getCertificationNumber(@RequestParam final String studentId, @RequestParam final String phoneNumber) {
+        memberService.isMemberExistsByMemberPasswordRequest(studentId, phoneNumber);
+
+        Long time = System.currentTimeMillis();
+        SmsCertificationNumber certificationNumber = smsService.sendCertificationNumberToPhoneNumber(phoneNumber, time );
+        return ResponseEntity.ok(certificationNumber);
+    }
+
+    @PatchMapping("/password")
+    public ResponseEntity<Void> changePassword(@RequestBody MemberPasswordChangeRequest request) {
+        boolean isChanged = memberService.changeMemberPassword(request);
+        return ResponseEntity.ok().build();
+    }
+
+}

--- a/src/main/java/team/dankookie/server4983/member/domain/Member.java
+++ b/src/main/java/team/dankookie/server4983/member/domain/Member.java
@@ -74,6 +74,10 @@ public class Member extends BaseEntity implements UserDetails {
         this.accountNumber = accountNumber;
     }
 
+    public void changePassword(String password) {
+        this.password = password;
+    }
+
     @Enumerated(EnumType.STRING)
     private UserRole role;
 

--- a/src/main/java/team/dankookie/server4983/member/dto/MemberCertificationRequest.java
+++ b/src/main/java/team/dankookie/server4983/member/dto/MemberCertificationRequest.java
@@ -1,0 +1,11 @@
+package team.dankookie.server4983.member.dto;
+
+public record MemberCertificationRequest(
+        String studentId,
+        String phoneNumber
+) {
+
+    public static MemberCertificationRequest of(String studentId, String phoneNumber) {
+        return new MemberCertificationRequest(studentId, phoneNumber);
+    }
+}

--- a/src/main/java/team/dankookie/server4983/member/dto/MemberPasswordChangeRequest.java
+++ b/src/main/java/team/dankookie/server4983/member/dto/MemberPasswordChangeRequest.java
@@ -1,0 +1,18 @@
+package team.dankookie.server4983.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.validator.constraints.Range;
+
+@RequiredArgsConstructor
+@Getter
+public class MemberPasswordChangeRequest {
+    private final String studentId;
+    private final String phoneNumber;
+    private final String password;
+
+    public static MemberPasswordChangeRequest of(String studentId, String phoneNumber, String password) {
+        return new MemberPasswordChangeRequest(studentId, phoneNumber, password);
+    }
+}

--- a/src/main/java/team/dankookie/server4983/member/service/MemberService.java
+++ b/src/main/java/team/dankookie/server4983/member/service/MemberService.java
@@ -1,12 +1,16 @@
 package team.dankookie.server4983.member.service;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import team.dankookie.server4983.common.exception.LoginFailedException;
 import team.dankookie.server4983.member.domain.Member;
 import team.dankookie.server4983.member.dto.LoginRequest;
+import team.dankookie.server4983.member.dto.MemberPasswordChangeRequest;
 import team.dankookie.server4983.member.repository.MemberRepository;
+
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service
@@ -38,4 +42,31 @@ public class MemberService {
         return member.getNickname();
     }
 
+    public boolean isMemberExistsByMemberPasswordRequest(String studentId, String phoneNumber) {
+
+        Member member = memberRepository.findByStudentId(studentId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 학번입니다."));
+
+        if (!member.getPhoneNumber().equals(phoneNumber)) {
+            throw new IllegalArgumentException("학번과 맞지 않는 휴대폰번호입니다.");
+        }
+
+        return true;
+    }
+
+    @Transactional
+    public boolean changeMemberPassword(MemberPasswordChangeRequest request) {
+        Member member = memberRepository.findByStudentId(request.getStudentId())
+                .orElseThrow(
+                        () -> new IllegalArgumentException("존재하지 않는 학번입니다.")
+                );
+
+        if (!member.getPhoneNumber().equals(request.getPhoneNumber())) {
+            throw new IllegalArgumentException("학번과 맞지 않는 휴대폰번호입니다.");
+        }
+
+        member.changePassword(passwordEncoder.encode(request.getPassword()));
+        return true;
+
+    }
 }

--- a/src/main/java/team/dankookie/server4983/sms/constant/SmsConstant.java
+++ b/src/main/java/team/dankookie/server4983/sms/constant/SmsConstant.java
@@ -1,0 +1,23 @@
+package team.dankookie.server4983.sms.constant;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@Getter
+public class SmsConstant {
+
+    @Value("${naver-cloud-sms.accessKey}")
+    public String accessKey;
+
+    @Value("${naver-cloud-sms.secretKey}")
+    public String secretKey;
+
+    @Value("${naver-cloud-sms.serviceId}")
+    public String serviceId;
+
+    @Value("${naver-cloud-sms.senderPhone}")
+    public String phone;
+
+}

--- a/src/main/java/team/dankookie/server4983/sms/dto/SmsCertificationNumber.java
+++ b/src/main/java/team/dankookie/server4983/sms/dto/SmsCertificationNumber.java
@@ -1,0 +1,10 @@
+package team.dankookie.server4983.sms.dto;
+
+public record SmsCertificationNumber(
+        String certificationNumber
+) {
+
+        public static SmsCertificationNumber of(String certificationNumber) {
+            return new SmsCertificationNumber(certificationNumber);
+        }
+}

--- a/src/main/java/team/dankookie/server4983/sms/dto/SmsMessageDto.java
+++ b/src/main/java/team/dankookie/server4983/sms/dto/SmsMessageDto.java
@@ -1,0 +1,10 @@
+package team.dankookie.server4983.sms.dto;
+
+public record SmsMessageDto(
+        String to,
+        String content
+) {
+    public static SmsMessageDto of(String to, String content) {
+        return new SmsMessageDto(to, content);
+    }
+}

--- a/src/main/java/team/dankookie/server4983/sms/dto/SmsResponse.java
+++ b/src/main/java/team/dankookie/server4983/sms/dto/SmsResponse.java
@@ -1,0 +1,21 @@
+package team.dankookie.server4983.sms.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@ToString
+@AllArgsConstructor
+@Getter
+@Builder
+public class SmsResponse {
+    String requestId;
+    LocalDateTime requestTime;
+    String statusCode;
+    String statusName;
+    int certificationNumber;
+}
+

--- a/src/main/java/team/dankookie/server4983/sms/dto/ToSmsServerRequest.java
+++ b/src/main/java/team/dankookie/server4983/sms/dto/ToSmsServerRequest.java
@@ -1,0 +1,20 @@
+package team.dankookie.server4983.sms.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Setter
+@Getter
+@Builder
+public class ToSmsServerRequest {
+    String type;
+    String contentType;
+    String countryCode;
+    String from;
+    String content;
+    List<SmsMessageDto> messages;
+
+}

--- a/src/main/java/team/dankookie/server4983/sms/service/SmsService.java
+++ b/src/main/java/team/dankookie/server4983/sms/service/SmsService.java
@@ -1,0 +1,146 @@
+package team.dankookie.server4983.sms.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.tomcat.util.codec.binary.Base64;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import team.dankookie.server4983.sms.constant.SmsConstant;
+import team.dankookie.server4983.sms.dto.SmsMessageDto;
+import team.dankookie.server4983.sms.dto.SmsResponse;
+import team.dankookie.server4983.sms.dto.SmsCertificationNumber;
+import team.dankookie.server4983.sms.dto.ToSmsServerRequest;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+
+@Slf4j
+@Service
+public class SmsService {
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+
+    private final SmsConstant smsConstant;
+
+    public SmsService(RestTemplateBuilder restTemplateBuilder, ObjectMapper objectMapper, SmsConstant smsConstant) {
+        this.restTemplate = restTemplateBuilder.build();
+        this.objectMapper = objectMapper;
+        this.smsConstant = smsConstant;
+    }
+
+
+    public SmsCertificationNumber sendCertificationNumberToPhoneNumber(String phoneNumber, Long time) {
+        int randomNumber = ThreadLocalRandom.current().nextInt(100000, 1000000);
+        String content = "안녕하세요! 4983 입니다. \n인증번호는 " + randomNumber + " 입니다.";
+        String apiServerUrl = "https://sens.apigw.ntruss.com/sms/v2/services/" + smsConstant.getServiceId() + "/messages";
+        SmsMessageDto smsMessageDto = SmsMessageDto.of(phoneNumber, content);
+
+        sendSms(time, apiServerUrl, smsMessageDto);
+
+        return SmsCertificationNumber.of(String.valueOf(randomNumber));
+        }
+
+    private void sendSms(Long time, String apiServerUrl, SmsMessageDto smsMessageDto) {
+        try {
+            List<SmsMessageDto> messages = setMessagesToList(smsMessageDto);
+
+            ToSmsServerRequest smsPayload = setToSmsServerPayload(smsMessageDto, messages);
+            String payload = objectMapper.writeValueAsString(smsPayload);
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(APPLICATION_JSON);
+            headers.set("x-ncp-apigw-timestamp", time.toString());
+            headers.set("x-ncp-iam-access-key", smsConstant.getAccessKey());
+            headers.set("x-ncp-apigw-signature-v2", makeSignature(time));
+
+            HttpEntity request = new HttpEntity(payload, headers);
+
+            SmsResponse smsResponse = restTemplate.exchange(
+                            apiServerUrl,
+                            HttpMethod.POST,
+                            request,
+                            SmsResponse.class
+                    )
+                    .getBody();
+
+        } catch (Exception e) {
+            log.error(e.getMessage());
+        }
+    }
+
+    public Optional<SmsResponse> sendSms(SmsMessageDto smsMessageDto) {
+        try {
+            Long time = System.currentTimeMillis();
+
+            List<SmsMessageDto> messages = setMessagesToList(smsMessageDto);
+
+            ToSmsServerRequest smsPayload = setToSmsServerPayload(smsMessageDto, messages);
+            String payload = objectMapper.writeValueAsString(smsPayload);
+
+
+        } catch (Exception e) {
+            log.error(e.getMessage());
+        }
+        return Optional.empty();
+    }
+
+    private ToSmsServerRequest setToSmsServerPayload(SmsMessageDto smsMessageDto, List<SmsMessageDto> messages) {
+        return ToSmsServerRequest.builder()
+                .type("SMS")
+                .contentType("COMM")
+                .countryCode("82")
+                .from(smsConstant.getPhone())
+                .content(smsMessageDto.content())
+                .messages(messages)
+                .build();
+    }
+
+    private List<SmsMessageDto> setMessagesToList(SmsMessageDto smsMessageDto) {
+        return new ArrayList<>(Collections.singleton(smsMessageDto));
+    }
+
+    private String makeSignature(Long time)  {
+        try {
+            String space = " ";
+            String newLine = "\n";
+            String method = "POST";
+            String url = "/sms/v2/services/" + smsConstant.getServiceId() + "/messages";
+
+            String timestamp = time.toString();
+
+            String message = method +
+                    space +
+                    url +
+                    newLine +
+                    timestamp +
+                    newLine +
+                    smsConstant.getAccessKey();
+
+            SecretKeySpec signingKey = new SecretKeySpec(smsConstant.getSecretKey().getBytes(UTF_8), "HmacSHA256");
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(signingKey);
+
+            byte[] rawHmac = mac.doFinal(message.getBytes(UTF_8));
+
+            return Base64.encodeBase64String(rawHmac);
+        } catch (Exception e) {
+            log.error(e.getMessage());
+        }
+        return "";
+
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -9,3 +9,4 @@ spring:
   config:
     import:
       - submodule/application-jwt.yml
+      - submodule/application-sms.yaml

--- a/src/main/resources/static/docs/member.html
+++ b/src/main/resources/static/docs/member.html
@@ -445,7 +445,15 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <ul class="sectlevel1">
 <li><a href="#_메인_문서">메인 문서</a>
 <ul class="sectlevel2">
-<li><a href="#_로그인_회원가입_관련_api_문서">로그인, 회원가입 관련 api 문서</a></li>
+<li><a href="#_로그인_성공">로그인 (성공)</a></li>
+<li><a href="#_로그인_학번_일치_안하는_경우">로그인 (학번 일치 안하는 경우)</a></li>
+<li><a href="#_로그인_비밀번호_일치_안하는_경우">로그인 (비밀번호 일치 안하는 경우)</a></li>
+<li><a href="#_비밀번호_인증번호_보내기_성공">비밀번호 인증번호 보내기 (성공)</a></li>
+<li><a href="#_비밀번호_인증번호_보내기_실패_학번_일치하지_않는_경우">비밀번호 인증번호 보내기 (실패 : 학번 일치하지 않는 경우)</a></li>
+<li><a href="#_비밀번호_인증번호_보내기_실패_휴대폰번호와_일치하지_않는_경우">비밀번호 인증번호 보내기 (실패: 휴대폰번호와 일치하지 않는 경우)</a></li>
+<li><a href="#_비밀번호_변경_성공">비밀번호 변경 (성공)</a></li>
+<li><a href="#_비밀번호_변경_실패_학번이_존재하지_않는_경우">비밀번호 변경 (실패: 학번이 존재하지 않는 경우)</a></li>
+<li><a href="#_비밀번호_변경_실패_휴대폰번호가_학번과_일치하지_않는_경우">비밀번호 변경 (실패: 휴대폰번호가 학번과 일치하지 않는 경우)</a></li>
 </ul>
 </li>
 </ul>
@@ -459,11 +467,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <p><a href="index.html">메인 문서</a></p>
 </div>
 <div class="sect2">
-<h3 id="_로그인_회원가입_관련_api_문서">로그인, 회원가입 관련 api 문서</h3>
+<h3 id="_로그인_성공">로그인 (성공)</h3>
 <div class="sect3">
-<h4 id="_로그인_성공">로그인 (성공)</h4>
-<div class="sect4">
-<h5 id="_request">Request</h5>
+<h4 id="_request">Request</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/login HTTP/1.1
@@ -501,12 +507,12 @@ Host: localhost:8080
 </tbody>
 </table>
 </div>
-<div class="sect4">
-<h5 id="_response">Response</h5>
+<div class="sect3">
+<h4 id="_response">Response</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Authorization: eyJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2OTMzODc1NjksImV4cCI6MTY5MzM4OTM2OX0.etf-iC5mAnxhcjE7_DfHNrahC5sVk-HkGGZxqIipPtc
+Authorization: eyJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2OTM0NzUxNDEsImV4cCI6MTY5MzQ3Njk0MX0.xQOHmAdruzlM8cjneLBPT0nzbdUa4mVHx6bXC1a-cbg
 Set-Cookie: refreshToken=refreshToken</code></pre>
 </div>
 </div>
@@ -554,10 +560,10 @@ Set-Cookie: refreshToken=refreshToken</code></pre>
 </table>
 </div>
 </div>
+<div class="sect2">
+<h3 id="_로그인_학번_일치_안하는_경우">로그인 (학번 일치 안하는 경우)</h3>
 <div class="sect3">
-<h4 id="_로그인_학번_일치_안하는_경우">로그인 (학번 일치 안하는 경우)</h4>
-<div class="sect4">
-<h5 id="_request_2">Request</h5>
+<h4 id="_request_2">Request</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/login HTTP/1.1
@@ -569,8 +575,8 @@ Host: localhost:8080
 </div>
 </div>
 </div>
-<div class="sect4">
-<h5 id="_response_2">Response</h5>
+<div class="sect3">
+<h4 id="_response_2">Response</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 401 Unauthorized
@@ -603,10 +609,10 @@ Content-Length: 50
 </table>
 </div>
 </div>
+<div class="sect2">
+<h3 id="_로그인_비밀번호_일치_안하는_경우">로그인 (비밀번호 일치 안하는 경우)</h3>
 <div class="sect3">
-<h4 id="_로그인_비밀번호_일치_안하는_경우">로그인 (비밀번호 일치 안하는 경우)</h4>
-<div class="sect4">
-<h5 id="_request_3">Request</h5>
+<h4 id="_request_3">Request</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/login HTTP/1.1
@@ -618,8 +624,8 @@ Host: localhost:8080
 </div>
 </div>
 </div>
-<div class="sect4">
-<h5 id="_response_3">Response</h5>
+<div class="sect3">
+<h4 id="_response_3">Response</h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 401 Unauthorized
@@ -652,6 +658,433 @@ Content-Length: 46
 </table>
 </div>
 </div>
+<div class="sect2">
+<h3 id="_비밀번호_인증번호_보내기_성공">비밀번호 인증번호 보내기 (성공)</h3>
+<div class="sect3">
+<h4 id="_request_4">Request</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/members/password/certification-number?studentId=201511111&amp;phoneNumber=01012345678 HTTP/1.1
+Content-Type: application/json
+Host: localhost:8080</code></pre>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_query_parameters">query parameters</h5>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>studentId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">학번</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>phoneNumber</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">휴대폰번호</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_4">Response</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 32
+
+{"certificationNumber":"123456"}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>certificationNumber</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">인증번호</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_비밀번호_인증번호_보내기_실패_학번_일치하지_않는_경우">비밀번호 인증번호 보내기 (실패 : 학번 일치하지 않는 경우)</h3>
+<div class="sect3">
+<h4 id="_request_5">Request</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/members/password/certification-number?studentId=201511111&amp;phoneNumber=01012345678 HTTP/1.1
+Content-Type: application/json
+Host: localhost:8080</code></pre>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_query_parameters_2">query parameters</h5>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>studentId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">학번</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>phoneNumber</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">휴대폰번호</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_5">Response</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 400 Bad Request
+Content-Type: application/json
+Content-Length: 50
+
+{"message":"존재하지 않는 학번입니다."}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">에러 메시지</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_비밀번호_인증번호_보내기_실패_휴대폰번호와_일치하지_않는_경우">비밀번호 인증번호 보내기 (실패: 휴대폰번호와 일치하지 않는 경우)</h3>
+<div class="sect3">
+<h4 id="_request_6">Request</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/members/password/certification-number?studentId=201511111&amp;phoneNumber=01012345678 HTTP/1.1
+Content-Type: application/json
+Host: localhost:8080</code></pre>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_query_parameters_3">query parameters</h5>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>studentId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">학번</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>phoneNumber</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">휴대폰번호</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_6">Response</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 400 Bad Request
+Content-Type: application/json
+Content-Length: 63
+
+{"message":"학번과 맞지 않는 휴대폰번호입니다."}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">에러 메시지</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_비밀번호_변경_성공">비밀번호 변경 (성공)</h3>
+<div class="sect3">
+<h4 id="_request_7">Request</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v1/members/password HTTP/1.1
+Content-Type: application/json
+Content-Length: 75
+Host: localhost:8080
+
+{"studentId":"studentId","phoneNumber":"phoneNumber","password":"password"}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>studentId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">학번</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>phoneNumber</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">휴대폰번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>password</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">비밀번호</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_response_7">Response</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_비밀번호_변경_실패_학번이_존재하지_않는_경우">비밀번호 변경 (실패: 학번이 존재하지 않는 경우)</h3>
+<div class="sect3">
+<h4 id="_request_8">Request</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v1/members/password HTTP/1.1
+Content-Type: application/json
+Content-Length: 75
+Host: localhost:8080
+
+{"studentId":"studentId","phoneNumber":"phoneNumber","password":"password"}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>studentId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">학번</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>phoneNumber</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">휴대폰번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>password</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">비밀번호</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_response_8">Response</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 400 Bad Request
+Content-Type: application/json
+Content-Length: 50
+
+{"message":"존재하지 않는 학번입니다."}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">에러 메시지</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_비밀번호_변경_실패_휴대폰번호가_학번과_일치하지_않는_경우">비밀번호 변경 (실패: 휴대폰번호가 학번과 일치하지 않는 경우)</h3>
+<div class="sect3">
+<h4 id="_request_9">Request</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v1/members/password HTTP/1.1
+Content-Type: application/json
+Content-Length: 75
+Host: localhost:8080
+
+{"studentId":"studentId","phoneNumber":"phoneNumber","password":"password"}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>studentId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">학번</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>phoneNumber</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">휴대폰번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>password</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">비밀번호</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_response_9">Response</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 400 Bad Request
+Content-Type: application/json
+Content-Length: 63
+
+{"message":"학번과 맞지 않는 휴대폰번호입니다."}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">에러 메시지</p></td>
+</tr>
+</tbody>
+</table>
+</div>
 </div>
 </div>
 </div>
@@ -659,7 +1092,7 @@ Content-Length: 46
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-08-30 18:26:02 +0900
+Last updated 2023-08-31 18:45:36 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/main/resources/static/docs/usedBook.html
+++ b/src/main/resources/static/docs/usedBook.html
@@ -484,7 +484,7 @@ Host: localhost:8080</code></pre>
 Content-Type: application/json
 Content-Length: 307
 
-[{"imageUrl":"imageUrl","bookStatus":"SALE","name":"책이름","tradeAvailableDate":"2023-08-30","createdAt":"2023-08-30T18:26:08.734524","price":10000},{"imageUrl":"imageUrl","bookStatus":"TRADE","name":"책이름","tradeAvailableDate":"2023-08-30","createdAt":"2023-08-30T18:26:08.734535","price":100000}]</code></pre>
+[{"imageUrl":"imageUrl","bookStatus":"SALE","name":"책이름","tradeAvailableDate":"2023-08-31","createdAt":"2023-08-31T18:45:40.082428","price":10000},{"imageUrl":"imageUrl","bookStatus":"TRADE","name":"책이름","tradeAvailableDate":"2023-08-31","createdAt":"2023-08-31T18:45:40.082439","price":100000}]</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
@@ -584,9 +584,9 @@ Host: localhost:8080</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json
-Content-Length: 307
+Content-Length: 306
 
-[{"imageUrl":"imageUrl","bookStatus":"SALE","name":"책이름","tradeAvailableDate":"2023-08-30","createdAt":"2023-08-30T18:26:08.814872","price":10000},{"imageUrl":"imageUrl","bookStatus":"TRADE","name":"책이름","tradeAvailableDate":"2023-08-30","createdAt":"2023-08-30T18:26:08.814877","price":100000}]</code></pre>
+[{"imageUrl":"imageUrl","bookStatus":"SALE","name":"책이름","tradeAvailableDate":"2023-08-31","createdAt":"2023-08-31T18:45:40.17181","price":10000},{"imageUrl":"imageUrl","bookStatus":"TRADE","name":"책이름","tradeAvailableDate":"2023-08-31","createdAt":"2023-08-31T18:45:40.171815","price":100000}]</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">

--- a/src/test/java/team/dankookie/server4983/common/BaseControllerTest.java
+++ b/src/test/java/team/dankookie/server4983/common/BaseControllerTest.java
@@ -2,18 +2,14 @@ package team.dankookie.server4983.common;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayNameGeneration;
-import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
@@ -23,11 +19,11 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 
 @SpringBootTest
 @AutoConfigureRestDocs
+@AutoConfigureMockMvc
 @ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
-@MockBean(JpaMetamodelMappingContext.class)
-@WebAppConfiguration
 public abstract class BaseControllerTest extends BaseDisplayNameConfig {
 
+    @Autowired
     protected MockMvc mockMvc;
 
     @Autowired

--- a/src/test/java/team/dankookie/server4983/member/controller/MemberPasswordControllerTest.java
+++ b/src/test/java/team/dankookie/server4983/member/controller/MemberPasswordControllerTest.java
@@ -1,0 +1,233 @@
+package team.dankookie.server4983.member.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.ResultActions;
+import team.dankookie.server4983.common.BaseControllerTest;
+import team.dankookie.server4983.common.exception.ErrorResponse;
+import team.dankookie.server4983.member.dto.MemberPasswordChangeRequest;
+import team.dankookie.server4983.member.service.MemberService;
+import team.dankookie.server4983.sms.dto.SmsCertificationNumber;
+import team.dankookie.server4983.sms.service.SmsService;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class MemberPasswordControllerTest extends BaseControllerTest {
+
+    @MockBean
+    MemberService memberService;
+
+    @MockBean
+    SmsService smsService;
+
+    @Test
+    void 학번과_휴대폰번호를_받으면_인증번호를_리턴한다() throws Exception {
+        //given
+        final String studentId = "201511111";
+        final String phoneNumber = "01012345678";
+        final String certificationNumber = "123456";
+        final SmsCertificationNumber smsCertificationNumber = SmsCertificationNumber.of(certificationNumber);
+
+        when(memberService.isMemberExistsByMemberPasswordRequest(studentId, phoneNumber))
+                .thenReturn(true);
+
+        when(smsService.sendCertificationNumberToPhoneNumber(anyString(), anyLong()))
+                .thenReturn(smsCertificationNumber);
+        //when
+
+        ResultActions resultActions = mockMvc.perform(get(API + "/members/password/certification-number")
+                        .contentType(APPLICATION_JSON)
+                        .param("studentId", studentId)
+                        .param("phoneNumber", phoneNumber))
+                .andDo(print());
+
+        //then
+        resultActions.andExpect(status().isOk())
+                .andDo(
+                        document("member/password/certification-number/success",
+                                queryParameters(
+                                        parameterWithName("studentId").description("학번"),
+                                        parameterWithName("phoneNumber").description("휴대폰번호")
+                                ),
+                                responseFields(
+                                        fieldWithPath("certificationNumber").description("인증번호")
+                                )
+                        )
+                );
+
+        String content = resultActions.andReturn().getResponse().getContentAsString(UTF_8);
+        assertThat(content).isEqualTo(objectMapper.writeValueAsString(SmsCertificationNumber.of(certificationNumber)));
+    }
+
+    @Test
+    void 학번이_올바르지_않으면_에러코드를_던진다() throws Exception {
+        //given
+        final String studentId = "201511111";
+        final String phoneNumber = "01012345678";
+        final String certificationNumber = "123456";
+        final SmsCertificationNumber smsCertificationNumber = SmsCertificationNumber.of(certificationNumber);
+
+        when(memberService.isMemberExistsByMemberPasswordRequest(studentId, phoneNumber))
+                .thenThrow(new IllegalArgumentException("존재하지 않는 학번입니다."));
+        //when
+
+        ResultActions resultActions = mockMvc.perform(get(API + "/members/password/certification-number")
+                        .contentType(APPLICATION_JSON)
+                        .param("studentId", studentId)
+                        .param("phoneNumber", phoneNumber))
+                .andDo(print());
+
+        //then
+        resultActions.andExpect(status().isBadRequest())
+                .andDo(
+                        document("member/password/certification-number/fail/studentId",
+                                queryParameters(
+                                        parameterWithName("studentId").description("학번"),
+                                        parameterWithName("phoneNumber").description("휴대폰번호")
+                                ),
+                                responseFields(
+                                        fieldWithPath("message").description("에러 메시지")
+                                )
+                        )
+                );
+
+        String content = resultActions.andReturn().getResponse().getContentAsString(UTF_8);
+        assertThat(content).isEqualTo(objectMapper.writeValueAsString(ErrorResponse.of("존재하지 않는 학번입니다.")));
+    }
+
+    @Test
+    void 학번과_휴대폰번호가_맞지_않으면_에러코드를_던진다() throws Exception {
+        //given
+        final String studentId = "201511111";
+        final String phoneNumber = "01012345678";
+        final String certificationNumber = "123456";
+        final SmsCertificationNumber smsCertificationNumber = SmsCertificationNumber.of(certificationNumber);
+
+        when(memberService.isMemberExistsByMemberPasswordRequest(studentId, phoneNumber))
+                .thenThrow(new IllegalArgumentException("학번과 맞지 않는 휴대폰번호입니다."));
+        //when
+
+        ResultActions resultActions = mockMvc.perform(get(API + "/members/password/certification-number")
+                        .contentType(APPLICATION_JSON)
+                        .param("studentId", studentId)
+                        .param("phoneNumber", phoneNumber))
+                .andDo(print());
+
+        //then
+        resultActions.andExpect(status().isBadRequest())
+                .andDo(
+                        document("member/password/certification-number/fail/phoneNumber",
+                                queryParameters(
+                                        parameterWithName("studentId").description("학번"),
+                                        parameterWithName("phoneNumber").description("휴대폰번호")
+                                ),
+                                responseFields(
+                                        fieldWithPath("message").description("에러 메시지")
+                                )
+                        )
+                );
+
+        String content = resultActions.andReturn().getResponse().getContentAsString(UTF_8);
+        assertThat(content).isEqualTo(objectMapper.writeValueAsString(ErrorResponse.of("학번과 맞지 않는 휴대폰번호입니다.")));
+    }
+
+    @Test
+    void 사용자의_비밀번호를_변경한다() throws Exception {
+        //given
+        final MemberPasswordChangeRequest request = MemberPasswordChangeRequest.of("studentId", "phoneNumber", "password");
+
+        when(memberService.changeMemberPassword(request))
+                .thenReturn(true);
+
+        //when
+        ResultActions resultActions = mockMvc.perform(patch(API + "/members/password")
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print());
+
+        //then
+        resultActions.andExpect(status().isOk())
+                .andDo(document("member/password/change/success",
+                        requestFields(
+                                fieldWithPath("studentId").description("학번"),
+                                fieldWithPath("phoneNumber").description("휴대폰번호"),
+                                fieldWithPath("password").description("비밀번호")
+                        )
+                ));
+    }
+
+    @Test
+    void 비밀번호_변경시_학번이_존재하지않으면_에러를_던진다() throws Exception {
+        //given
+        final MemberPasswordChangeRequest request = MemberPasswordChangeRequest.of("studentId", "phoneNumber", "password");
+
+        when(memberService.changeMemberPassword(any(MemberPasswordChangeRequest.class)))
+                .thenThrow(new IllegalArgumentException("존재하지 않는 학번입니다."));
+
+        //when
+        ResultActions resultActions = mockMvc.perform(patch(API + "/members/password")
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print());
+
+        //then
+        resultActions.andExpect(status().isBadRequest())
+                .andDo(document("member/password/change/fail/studentId",
+                        requestFields(
+                                fieldWithPath("studentId").description("학번"),
+                                fieldWithPath("phoneNumber").description("휴대폰번호"),
+                                fieldWithPath("password").description("비밀번호")
+                        ),
+                        responseFields(
+                                fieldWithPath("message").description("에러 메시지")
+                        )
+                ));
+
+        String content = resultActions.andReturn().getResponse().getContentAsString(UTF_8);
+        assertThat(content).isEqualTo(objectMapper.writeValueAsString(ErrorResponse.of("존재하지 않는 학번입니다.")));
+    }
+
+    @Test
+    void 비밀번호_변경시_학번과_휴대폰번호가_일치하지_않으면_에러를_던진다() throws Exception {
+        //given
+        final MemberPasswordChangeRequest request = MemberPasswordChangeRequest.of("studentId", "phoneNumber", "password");
+
+        when(memberService.changeMemberPassword(any(MemberPasswordChangeRequest.class)))
+                .thenThrow(new IllegalArgumentException("학번과 맞지 않는 휴대폰번호입니다."));
+
+        //when
+        ResultActions resultActions = mockMvc.perform(patch(API + "/members/password")
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print());
+
+        //then
+        resultActions.andExpect(status().isBadRequest())
+                .andDo(document("member/password/change/fail/phonenumber",
+                        requestFields(
+                                fieldWithPath("studentId").description("학번"),
+                                fieldWithPath("phoneNumber").description("휴대폰번호"),
+                                fieldWithPath("password").description("비밀번호")
+                        ),
+                        responseFields(
+                                fieldWithPath("message").description("에러 메시지")
+                        )
+                ));
+
+        String content = resultActions.andReturn().getResponse().getContentAsString(UTF_8);
+        assertThat(content).isEqualTo(objectMapper.writeValueAsString(ErrorResponse.of("학번과 맞지 않는 휴대폰번호입니다.")));
+    }
+
+}

--- a/src/test/java/team/dankookie/server4983/member/service/MemberServiceTest.java
+++ b/src/test/java/team/dankookie/server4983/member/service/MemberServiceTest.java
@@ -8,6 +8,7 @@ import team.dankookie.server4983.common.BaseServiceTest;
 import team.dankookie.server4983.common.exception.LoginFailedException;
 import team.dankookie.server4983.member.domain.Member;
 import team.dankookie.server4983.member.dto.LoginRequest;
+import team.dankookie.server4983.member.dto.MemberPasswordChangeRequest;
 import team.dankookie.server4983.member.repository.MemberRepository;
 
 import java.util.Optional;
@@ -59,7 +60,8 @@ class MemberServiceTest extends BaseServiceTest {
         //when
         //then
         assertThatThrownBy(() -> memberService.login(loginRequest))
-                .isInstanceOf(LoginFailedException.class);
+                .isInstanceOf(LoginFailedException.class)
+                .hasMessage("존재하지 않는 학번입니다.");
 
     }
 
@@ -78,7 +80,8 @@ class MemberServiceTest extends BaseServiceTest {
         //when
         //then
         assertThatThrownBy(() -> memberService.login(loginRequest))
-                .isInstanceOf(LoginFailedException.class);
+                .isInstanceOf(LoginFailedException.class)
+                .hasMessage("잘못된 비밀번호입니다!");
 
     }
 
@@ -108,8 +111,101 @@ class MemberServiceTest extends BaseServiceTest {
         //when
         //then
         assertThatThrownBy(() -> memberService.findMemberNicknameByStudentId(studentId))
-                .isInstanceOf(LoginFailedException.class);
+                .isInstanceOf(LoginFailedException.class)
+                .hasMessage("존재하지 않는 학번입니다.");
     }
-    
+
+    @Test
+    void 학번과_휴대폰번호가_일치하는_회원이_있으면_true를_리턴한다() {
+        //given
+        String studentId = "studentId";
+        String phoneNumber = "phoneNumber";
+
+        when(memberRepository.findByStudentId(studentId))
+                .thenReturn(Optional.of(Member.builder().phoneNumber(phoneNumber).build()));
+        //when
+        boolean isMemberExists = memberService.isMemberExistsByMemberPasswordRequest(studentId, phoneNumber);
+        //then
+        assertThat(isMemberExists).isEqualTo(true);
+    }
+
+    @Test
+    void 학번과_일치하는_회원이_없으면_에러를_던진다() {
+        //given
+        String studentId = "studentId";
+        String phoneNumber = "phoneNumber";
+
+        when(memberRepository.findByStudentId(studentId))
+                .thenThrow(new IllegalArgumentException("존재하지 않는 학번입니다."));
+        //when
+        //then
+        assertThatThrownBy(() -> memberService.isMemberExistsByMemberPasswordRequest(studentId, phoneNumber))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("존재하지 않는 학번입니다.");
+    }
+
+    @Test
+    void 학번과_휴대폰번호가_일치하는_회원이_없으면_에러를_던진다() {
+        //given
+        String studentId = "studentId";
+        String phoneNumber = "phoneNumber";
+
+        when(memberRepository.findByStudentId(studentId))
+                .thenReturn(Optional.of(Member.builder().phoneNumber("wrongPhoneNumber").build()));
+        //when
+        //then
+        assertThatThrownBy(() -> memberService.isMemberExistsByMemberPasswordRequest(studentId, phoneNumber))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("학번과 맞지 않는 휴대폰번호입니다.");
+    }
+
+    @Test
+    void 학번과_비밀번호_변경할_비밀번호를_받으면_비밀번호를_변경한다() {
+        //given
+        MemberPasswordChangeRequest request = MemberPasswordChangeRequest.of("studentId", "phoneNumber", "password");
+
+        Member member = Member.builder().nickname("nickname").studentId("studentId").phoneNumber("phoneNumber").password("password").build();
+
+        when(memberRepository.findByStudentId(request.getStudentId()))
+                .thenReturn(Optional.of(member));
+
+        //when
+        boolean isChanged = memberService.changeMemberPassword(request);
+
+        //then
+        assertThat(isChanged).isTrue();
+
+    }
+
+
+    @Test
+    void 비밀번호_변경_학번과_일치하는_회원이_없으면_에러를_던진다() {
+        //given
+        String studentId = "studentId";
+        String phoneNumber = "phoneNumber";
+
+        when(memberRepository.findByStudentId(studentId))
+                .thenThrow(new IllegalArgumentException("존재하지 않는 학번입니다."));
+        //when
+        //then
+        assertThatThrownBy(() -> memberService.isMemberExistsByMemberPasswordRequest(studentId, phoneNumber))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("존재하지 않는 학번입니다.");
+    }
+
+    @Test
+    void 비밀번호_변경_학번과_휴대폰번호가_일치하는_회원이_없으면_에러를_던진다() {
+        //given
+        String studentId = "studentId";
+        String phoneNumber = "phoneNumber";
+
+        when(memberRepository.findByStudentId(studentId))
+                .thenReturn(Optional.of(Member.builder().phoneNumber("wrongPhoneNumber").build()));
+        //when
+        //then
+        assertThatThrownBy(() -> memberService.isMemberExistsByMemberPasswordRequest(studentId, phoneNumber))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("학번과 맞지 않는 휴대폰번호입니다.");
+    }
 
 }

--- a/src/test/java/team/dankookie/server4983/sms/service/SmsServiceTest.java
+++ b/src/test/java/team/dankookie/server4983/sms/service/SmsServiceTest.java
@@ -1,0 +1,83 @@
+package team.dankookie.server4983.sms.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import team.dankookie.server4983.sms.constant.SmsConstant;
+import team.dankookie.server4983.sms.dto.SmsCertificationNumber;
+import team.dankookie.server4983.sms.dto.SmsResponse;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+@RestClientTest({SmsService.class})
+class SmsServiceTest  {
+
+    @Autowired
+    private MockRestServiceServer mockServer;
+
+    @Autowired
+    SmsService smsService;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockBean
+    SmsConstant smsConstant;
+
+    @Test
+    void test() throws JsonProcessingException {
+        //given
+        Mockito.when(smsConstant.getServiceId())
+                .thenReturn("testServiceId");
+
+        String apiServerUrl = "https://sens.apigw.ntruss.com/sms/v2/services/" + smsConstant.getServiceId() + "/messages";
+
+        Long time = System.currentTimeMillis();
+
+        SmsResponse apiResponse = SmsResponse
+                .builder()
+                .requestId("RSSA-1693420097041-6351-57658285-GcAgkOfY")
+                .requestTime(LocalDateTime.now())
+                .statusCode(HttpStatus.ACCEPTED.toString())
+                .certificationNumber(123123)
+                .build();
+
+        mockServer.expect(requestTo(apiServerUrl))
+                .andRespond(withSuccess(objectMapper.writeValueAsString(apiResponse), MediaType.APPLICATION_JSON));
+
+        //when
+        SmsCertificationNumber smsCertificationNumber = smsService.sendCertificationNumberToPhoneNumber("01073352306", time);
+
+        //then
+        assertThat(smsCertificationNumber.certificationNumber()).isNotEmpty();
+    }
+
+}
+
+@SpringBootTest
+class SmsApiTest {
+
+    @Autowired
+    SmsService smsService;
+
+    @Disabled
+    @Test
+    void 실제_api_테스트() {
+        Long time = System.currentTimeMillis();
+        smsService.sendCertificationNumberToPhoneNumber("01057490339", time);
+    }
+
+}


### PR DESCRIPTION
## ✔ 지라 이슈 번호
DAN-34

## 📒 작업 내용
- BaseControllerTest class 수정 
- Sms 전송 서비스 구현 
- 비밀번호 재설정 로직 구현 
- 비밀번호 재설정 시 이전에 필요한 인증번호 로직 구현

## 📢 리뷰어에게 하고 싶은 말
- Sms Service Api Test 코드 쪽 구조가 괜찮은지 봐주세요!


## 📌 PR 전 체크 사항
- [x] base 브랜치가 **develop** 또는 **main** 브랜치로 되어있나요?
- [x] PR title에 PR Type을 표시해 두었나요? (feat:, fix:, refact: ...)
- [x] test가 모두 통과 되었나요? 