### PR TITLE
feat: 회원가입 페이지 관련 api 로직 구현 및 로그인 api 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
 //    db (h2, mysql)

--- a/src/docs/asciidoc/member.adoc
+++ b/src/docs/asciidoc/member.adoc
@@ -121,3 +121,61 @@ include::{snippets}/member/password/change/fail/phoneNumber/request-fields.adoc[
 
 include::{snippets}/member/password/change/fail/phoneNumber/http-response.adoc[]
 include::{snippets}/member/password/change/fail/phoneNumber/response-fields.adoc[]
+
+
+=== 학번 중복 확인 (성공)
+
+==== Request
+
+include::{snippets}/member-register/duplicate/studentId/success/http-request.adoc[]
+===== query parameters
+include::{snippets}/member-register/duplicate/studentId/success/query-parameters.adoc[]
+
+==== Response
+
+include::{snippets}/member-register/duplicate/studentId/success/http-response.adoc[]
+
+=== 학번 중복 확인 (실패 : 학번 중복)
+
+==== Request
+include::{snippets}/member-register/duplicate/studentId/fail/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/member-register/duplicate/studentId/fail/http-response.adoc[]
+include::{snippets}/member-register/duplicate/studentId/fail/response-fields.adoc[]
+
+=== 닉네임 중복 확인 (성공)
+
+==== Request
+
+include::{snippets}/member-register/duplicate/nickname/success/http-request.adoc[]
+===== query parameters
+include::{snippets}/member-register/duplicate/nickname/success/query-parameters.adoc[]
+
+==== Response
+
+include::{snippets}/member-register/duplicate/nickname/success/http-response.adoc[]
+include::{snippets}/member-register/duplicate/nickname/success/response-fields.adoc[]
+
+=== 닉네임 중복 확인 (실패 : 닉네임 중복)
+
+==== Request
+
+include::{snippets}/member-register/duplicate/nickname/fail/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/member-register/duplicate/nickname/fail/http-response.adoc[]
+include::{snippets}/member-register/duplicate/nickname/fail/response-fields.adoc[]
+
+=== 회원가입 (성공)
+
+==== Request
+
+include::{snippets}/member-register/success/http-request.adoc[]
+include::{snippets}/member-register/success/request-fields.adoc[]
+
+==== Response
+
+include::{snippets}/member-register/success/http-response.adoc[]

--- a/src/main/java/team/dankookie/server4983/Server4983Application.java
+++ b/src/main/java/team/dankookie/server4983/Server4983Application.java
@@ -2,7 +2,10 @@ package team.dankookie.server4983;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import team.dankookie.server4983.jwt.constants.TokenSecretKey;
 
+@EnableConfigurationProperties(TokenSecretKey.class)
 @SpringBootApplication
 public class Server4983Application {
 

--- a/src/main/java/team/dankookie/server4983/common/config/WebMvcConfig.java
+++ b/src/main/java/team/dankookie/server4983/common/config/WebMvcConfig.java
@@ -1,0 +1,23 @@
+package team.dankookie.server4983.common.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import team.dankookie.server4983.jwt.constants.TokenSecretKey;
+import team.dankookie.server4983.jwt.resolver.LoginResolver;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final TokenSecretKey tokenSecretKey;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new LoginResolver(tokenSecretKey));
+
+    }
+}

--- a/src/main/java/team/dankookie/server4983/common/config/filter/JwtTokenFilter.java
+++ b/src/main/java/team/dankookie/server4983/common/config/filter/JwtTokenFilter.java
@@ -89,7 +89,7 @@ public class JwtTokenFilter extends OncePerRequestFilter {
             return;
         }
 
-        String generateAccessToken = JwtTokenUtils.generateAccessToken(refreshTokenEntity.get().getMember().getNickname(), key, TokenDuration.REFRESH_TOKEN_DURATION.getDuration());
+        String generateAccessToken = JwtTokenUtils.generateJwtToken(refreshTokenEntity.get().getMember().getNickname(), key, TokenDuration.REFRESH_TOKEN_DURATION.getDuration());
 
         response.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + generateAccessToken);
 
@@ -97,7 +97,7 @@ public class JwtTokenFilter extends OncePerRequestFilter {
     }
 
     private void setAuthentication(HttpServletRequest request, String accessToken) {
-        String username = JwtTokenUtils.getUsername(accessToken, key);
+        String username = JwtTokenUtils.getNickname(accessToken, key);
         Member member = memberService.loadUserByUsername(username);
 
         UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(

--- a/src/main/java/team/dankookie/server4983/common/dto/BaseMessageResponse.java
+++ b/src/main/java/team/dankookie/server4983/common/dto/BaseMessageResponse.java
@@ -1,0 +1,9 @@
+package team.dankookie.server4983.common.dto;
+
+public record BaseMessageResponse(
+        String message
+) {
+    public static BaseMessageResponse of(String message) {
+        return new BaseMessageResponse(message);
+    }
+}

--- a/src/main/java/team/dankookie/server4983/common/exception/NotAuthorizedException.java
+++ b/src/main/java/team/dankookie/server4983/common/exception/NotAuthorizedException.java
@@ -1,0 +1,12 @@
+package team.dankookie.server4983.common.exception;
+
+public class NotAuthorizedException extends RuntimeException {
+
+    public NotAuthorizedException() {
+        super("존재하지 않는 토큰입니다.");
+    }
+
+    public NotAuthorizedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/team/dankookie/server4983/jwt/constants/TokenSecretKey.java
+++ b/src/main/java/team/dankookie/server4983/jwt/constants/TokenSecretKey.java
@@ -1,0 +1,12 @@
+package team.dankookie.server4983.jwt.constants;
+
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Data
+@ConfigurationProperties(prefix = "jwt")
+public class TokenSecretKey {
+
+    private String secretKey;
+}

--- a/src/main/java/team/dankookie/server4983/jwt/domain/RefreshToken.java
+++ b/src/main/java/team/dankookie/server4983/jwt/domain/RefreshToken.java
@@ -3,6 +3,7 @@ package team.dankookie.server4983.jwt.domain;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import team.dankookie.server4983.member.domain.Member;
@@ -21,4 +22,10 @@ public class RefreshToken {
 
     @NotNull
     private String refreshToken;
+
+    @Builder
+    public RefreshToken(Member member, String refreshToken) {
+        this.member = member;
+        this.refreshToken = refreshToken;
+    }
 }

--- a/src/main/java/team/dankookie/server4983/jwt/dto/AccessToken.java
+++ b/src/main/java/team/dankookie/server4983/jwt/dto/AccessToken.java
@@ -1,0 +1,9 @@
+package team.dankookie.server4983.jwt.dto;
+
+public record AccessToken (
+        String value
+) {
+    public static AccessToken of(String value) {
+        return new AccessToken(value);
+    }
+}

--- a/src/main/java/team/dankookie/server4983/jwt/resolver/LoginResolver.java
+++ b/src/main/java/team/dankookie/server4983/jwt/resolver/LoginResolver.java
@@ -1,0 +1,45 @@
+package team.dankookie.server4983.jwt.resolver;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import team.dankookie.server4983.common.exception.NotAuthorizedException;
+import team.dankookie.server4983.jwt.constants.TokenSecretKey;
+import team.dankookie.server4983.jwt.dto.AccessToken;
+import team.dankookie.server4983.jwt.util.JwtTokenUtils;
+
+@Slf4j
+@RequiredArgsConstructor
+public class LoginResolver implements HandlerMethodArgumentResolver {
+
+    private final TokenSecretKey tokenSecretKey;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().equals(AccessToken.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+
+        String accessToken = webRequest.getHeader(HttpHeaders.AUTHORIZATION);
+
+        if (accessToken == null || accessToken.equals("")) {
+            log.error("accessToken 토큰이 존재하지 않습니다.");
+            throw new NotAuthorizedException();
+        }
+
+        if (JwtTokenUtils.isTokenExpired(accessToken, tokenSecretKey.getSecretKey())) {
+
+            log.error("accessToken 토큰이 만료되었습니다.");
+            throw new NotAuthorizedException();
+        }
+
+        return AccessToken.of(accessToken);
+    }
+}

--- a/src/main/java/team/dankookie/server4983/jwt/service/RefreshTokenService.java
+++ b/src/main/java/team/dankookie/server4983/jwt/service/RefreshTokenService.java
@@ -1,0 +1,17 @@
+package team.dankookie.server4983.jwt.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import team.dankookie.server4983.jwt.domain.RefreshToken;
+import team.dankookie.server4983.jwt.repository.RefreshTokenRepository;
+
+@RequiredArgsConstructor
+@Service
+public class RefreshTokenService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public RefreshToken save(RefreshToken refreshToken) {
+        return refreshTokenRepository.save(refreshToken);
+    }
+}

--- a/src/main/java/team/dankookie/server4983/jwt/util/JwtTokenUtils.java
+++ b/src/main/java/team/dankookie/server4983/jwt/util/JwtTokenUtils.java
@@ -11,9 +11,9 @@ import java.util.Date;
 
 public class JwtTokenUtils {
 
-    public static Boolean validate(String token, String userName, String key) {
-        String usernameByToken = getUsername(token, key);
-        return usernameByToken.equals(userName) && !isTokenExpired(token, key);
+    public static Boolean validate(String token, String nickname, String key) {
+        String usernameByToken = getNickname(token, key);
+        return usernameByToken.equals(nickname) && !isTokenExpired(token, key);
     }
 
     public static Claims extractAllClaims(String token, String key) {
@@ -24,8 +24,8 @@ public class JwtTokenUtils {
                 .getBody();
     }
 
-    public static String getUsername(String token, String key) {
-        return extractAllClaims(token, key).get("username", String.class);
+    public static String getNickname(String token, String key) {
+        return extractAllClaims(token, key).get("nickname", String.class);
     }
 
     private static Key getSigningKey(String secretKey) {
@@ -38,13 +38,13 @@ public class JwtTokenUtils {
         return expiration.before(new Date());
     }
 
-    public static String generateAccessToken(String username, String key, long expiredTimeMs) {
-        return doGenerateToken(username, expiredTimeMs, key);
+    public static String generateJwtToken(String nickname, String key, long expiredTimeMs) {
+        return doGenerateToken(nickname, expiredTimeMs, key);
     }
 
-    private static String doGenerateToken(String username, long expireTime, String key) {
+    private static String doGenerateToken(String nickname, long expireTime, String key) {
         Claims claims = Jwts.claims();
-        claims.put("username", username);
+        claims.put("nickname", nickname);
 
         return Jwts.builder()
                 .setClaims(claims)

--- a/src/main/java/team/dankookie/server4983/member/controller/MemberPasswordController.java
+++ b/src/main/java/team/dankookie/server4983/member/controller/MemberPasswordController.java
@@ -1,6 +1,5 @@
 package team.dankookie.server4983.member.controller;
 
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -24,7 +23,7 @@ public class MemberPasswordController {
         memberService.isMemberExistsByMemberPasswordRequest(studentId, phoneNumber);
 
         Long time = System.currentTimeMillis();
-        SmsCertificationNumber certificationNumber = smsService.sendCertificationNumberToPhoneNumber(phoneNumber, time );
+        SmsCertificationNumber certificationNumber = smsService.sendCertificationNumberToPhoneNumber(phoneNumber, time);
         return ResponseEntity.ok(certificationNumber);
     }
 

--- a/src/main/java/team/dankookie/server4983/member/controller/MemberRegisterController.java
+++ b/src/main/java/team/dankookie/server4983/member/controller/MemberRegisterController.java
@@ -1,0 +1,46 @@
+package team.dankookie.server4983.member.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import team.dankookie.server4983.common.dto.BaseMessageResponse;
+import team.dankookie.server4983.member.domain.Member;
+import team.dankookie.server4983.member.dto.MemberRegisterRequest;
+import team.dankookie.server4983.member.service.MemberService;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/register")
+public class MemberRegisterController {
+
+    private final MemberService memberService;
+
+    @GetMapping("/duplicate/studentId")
+    public ResponseEntity<BaseMessageResponse> isStudentIdDuplicate(@RequestParam String studentId) {
+        boolean isDuplicate = memberService.isStudentIdDuplicate(studentId);
+
+        if (isDuplicate) {
+            return ResponseEntity.badRequest().body(BaseMessageResponse.of("이미 가입된 학번 정보입니다."));
+        } else {
+            return ResponseEntity.ok().build();
+        }
+
+    }
+
+    @GetMapping("/duplicate/nickname")
+    public ResponseEntity<BaseMessageResponse> isNicknameDuplicate(@RequestParam String nickname) {
+        boolean isDuplicate = memberService.isNicknameDuplicate(nickname);
+
+        if (isDuplicate) {
+            return ResponseEntity.badRequest().body(BaseMessageResponse.of("사용 중인 닉네임이에요!"));
+        } else {
+            return ResponseEntity.ok(BaseMessageResponse.of("사용 가능한 닉네임입니다."));
+        }
+    }
+
+    @PostMapping
+    public ResponseEntity<Void> register(@RequestBody MemberRegisterRequest request) {
+        Member member = memberService.register(request);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/team/dankookie/server4983/member/domain/Member.java
+++ b/src/main/java/team/dankookie/server4983/member/domain/Member.java
@@ -62,7 +62,7 @@ public class Member extends BaseEntity implements UserDetails {
     private Boolean marketingAgree;
 
     @Builder
-    public Member(String studentId, Department department, Integer yearOfAdmission, String nickname, String password, String phoneNumber, String accountHolder, AccountBank accountBank, String accountNumber) {
+    public Member(String studentId, Department department, Integer yearOfAdmission, String nickname, String password, String phoneNumber, String accountHolder, AccountBank accountBank, String accountNumber, boolean marketingAgree){
         this.studentId = studentId;
         this.department = department;
         this.yearOfAdmission = yearOfAdmission;
@@ -72,6 +72,8 @@ public class Member extends BaseEntity implements UserDetails {
         this.accountHolder = accountHolder;
         this.accountBank = accountBank;
         this.accountNumber = accountNumber;
+        this.marketingAgree = marketingAgree;
+        this.role = UserRole.USER;
     }
 
     public void changePassword(String password) {

--- a/src/main/java/team/dankookie/server4983/member/dto/MemberRegisterRequest.java
+++ b/src/main/java/team/dankookie/server4983/member/dto/MemberRegisterRequest.java
@@ -1,0 +1,60 @@
+package team.dankookie.server4983.member.dto;
+
+import team.dankookie.server4983.book.constant.Department;
+import team.dankookie.server4983.member.constant.AccountBank;
+import team.dankookie.server4983.member.domain.Member;
+
+public record MemberRegisterRequest(
+        String studentId,
+        Department department,
+        int yearOfAdmission,
+        String nickname,
+        String password,
+        String phoneNumber,
+        boolean marketingAgree,
+        String accountHolder,
+        AccountBank accountBank,
+        String accountNumber
+
+) {
+
+    public static MemberRegisterRequest of(String studentId,
+                                           Department department,
+                                           int yearOfAdmission,
+                                           String nickname,
+                                           String password,
+                                           String phoneNumber,
+                                           boolean marketingAgree,
+                                           String accountHolder,
+                                           AccountBank accountBank,
+                                           String accountNumber
+    ) {
+        return new MemberRegisterRequest(
+                studentId,
+                department,
+                yearOfAdmission,
+                nickname,
+                password,
+                phoneNumber,
+                marketingAgree,
+                accountHolder,
+                accountBank,
+                accountNumber
+        );
+    }
+
+    public Member toEntity() {
+        return Member.builder()
+                .studentId(studentId)
+                .department(department)
+                .yearOfAdmission(yearOfAdmission)
+                .nickname(nickname)
+                .password(password)
+                .phoneNumber(phoneNumber)
+                .marketingAgree(marketingAgree)
+                .accountHolder(accountHolder)
+                .accountBank(accountBank)
+                .accountNumber(accountNumber)
+                .build();
+    }
+}

--- a/src/main/java/team/dankookie/server4983/member/repository/MemberRepository.java
+++ b/src/main/java/team/dankookie/server4983/member/repository/MemberRepository.java
@@ -9,5 +9,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByNickname(String nickname);
     Optional<Member> findByStudentId(String studentId);
 
+    boolean existsByStudentId(String studentId);
+
+    boolean existsByNickname(String nickname);
 
 }

--- a/src/main/java/team/dankookie/server4983/member/service/MemberService.java
+++ b/src/main/java/team/dankookie/server4983/member/service/MemberService.java
@@ -1,16 +1,15 @@
 package team.dankookie.server4983.member.service;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import team.dankookie.server4983.common.exception.LoginFailedException;
 import team.dankookie.server4983.member.domain.Member;
 import team.dankookie.server4983.member.dto.LoginRequest;
 import team.dankookie.server4983.member.dto.MemberPasswordChangeRequest;
+import team.dankookie.server4983.member.dto.MemberRegisterRequest;
 import team.dankookie.server4983.member.repository.MemberRepository;
-
-import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service
@@ -36,10 +35,10 @@ public class MemberService {
         return true;
     }
 
-    public String findMemberNicknameByStudentId(String studentId) {
+    public Member findMemberNicknameByStudentId(String studentId) {
         Member member = memberRepository.findByStudentId(studentId)
                 .orElseThrow(() -> new LoginFailedException("존재하지 않는 학번입니다."));
-        return member.getNickname();
+        return member;
     }
 
     public boolean isMemberExistsByMemberPasswordRequest(String studentId, String phoneNumber) {
@@ -67,6 +66,19 @@ public class MemberService {
 
         member.changePassword(passwordEncoder.encode(request.getPassword()));
         return true;
-
     }
+
+    public boolean isStudentIdDuplicate(String studentId) {
+        return memberRepository.existsByStudentId(studentId);
+    }
+
+    public boolean isNicknameDuplicate(String nickname) {
+        return memberRepository.existsByNickname(nickname);
+    }
+
+    @Transactional
+    public Member register(MemberRegisterRequest request) {
+        return memberRepository.save(request.toEntity());
+    }
+
 }

--- a/src/main/resources/static/docs/member.html
+++ b/src/main/resources/static/docs/member.html
@@ -454,6 +454,11 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_비밀번호_변경_성공">비밀번호 변경 (성공)</a></li>
 <li><a href="#_비밀번호_변경_실패_학번이_존재하지_않는_경우">비밀번호 변경 (실패: 학번이 존재하지 않는 경우)</a></li>
 <li><a href="#_비밀번호_변경_실패_휴대폰번호가_학번과_일치하지_않는_경우">비밀번호 변경 (실패: 휴대폰번호가 학번과 일치하지 않는 경우)</a></li>
+<li><a href="#_학번_중복_확인_성공">학번 중복 확인 (성공)</a></li>
+<li><a href="#_학번_중복_확인_실패_학번_중복">학번 중복 확인 (실패 : 학번 중복)</a></li>
+<li><a href="#_닉네임_중복_확인_성공">닉네임 중복 확인 (성공)</a></li>
+<li><a href="#_닉네임_중복_확인_실패_닉네임_중복">닉네임 중복 확인 (실패 : 닉네임 중복)</a></li>
+<li><a href="#_회원가입_성공">회원가입 (성공)</a></li>
 </ul>
 </li>
 </ul>
@@ -512,8 +517,8 @@ Host: localhost:8080
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Authorization: eyJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2OTM0NzUxNDEsImV4cCI6MTY5MzQ3Njk0MX0.xQOHmAdruzlM8cjneLBPT0nzbdUa4mVHx6bXC1a-cbg
-Set-Cookie: refreshToken=refreshToken</code></pre>
+Authorization: eyJhbGciOiJIUzI1NiJ9.eyJuaWNrbmFtZSI6Im5pY2tuYW1lIiwiaWF0IjoxNjk0MzY3NDI0LCJleHAiOjE2OTQzNjkyMjR9.hDqRggurzJvvhbSXUkDh0SxW3HGD_7ZsBbm9-aB34JQ
+Set-Cookie: refreshToken=eyJhbGciOiJIUzI1NiJ9.eyJuaWNrbmFtZSI6Im5pY2tuYW1lIiwiaWF0IjoxNjk0MzY3NDI0LCJleHAiOjE2OTU1NzcwMjR9.vPJ17jfWZxzLJcSy7HoMQwNHelFdRlXPLc25veOfLew</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1086,13 +1091,276 @@ Content-Length: 63
 </table>
 </div>
 </div>
+<div class="sect2">
+<h3 id="_학번_중복_확인_성공">학번 중복 확인 (성공)</h3>
+<div class="sect3">
+<h4 id="_request_10">Request</h4>
+<div class="paragraph">
+<p>Unresolved directive in member.adoc - include::/Users/wan2daaa/Documents/4983/server-4983/build/generated-snippets/member-register/duplicate/studentId/http-request.adoc[]
+===== query parameters
+Unresolved directive in member.adoc - include::/Users/wan2daaa/Documents/4983/server-4983/build/generated-snippets/member-register/duplicate/studentId/query-parameters.adoc[]</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_10">Response</h4>
+<div class="paragraph">
+<p>Unresolved directive in member.adoc - include::/Users/wan2daaa/Documents/4983/server-4983/build/generated-snippets/member-register/duplicate/studentId/http-response.adoc[]</p>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_학번_중복_확인_실패_학번_중복">학번 중복 확인 (실패 : 학번 중복)</h3>
+<div class="sect3">
+<h4 id="_request_11">Request</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/register/duplicate/studentId?studentId=202023604 HTTP/1.1
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_11">Response</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 400 Bad Request
+Content-Type: application/json
+Content-Length: 54
+
+{"message":"이미 가입된 학번 정보입니다."}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">에러 메시지</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_닉네임_중복_확인_성공">닉네임 중복 확인 (성공)</h3>
+<div class="sect3">
+<h4 id="_request_12">Request</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/register/duplicate/nickname?nickname=testNickname HTTP/1.1
+Host: localhost:8080</code></pre>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_query_parameters_4">query parameters</h5>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">닉네임</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_12">Response</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 50
+
+{"message":"사용 가능한 닉네임입니다."}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">성공 메시지</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_닉네임_중복_확인_실패_닉네임_중복">닉네임 중복 확인 (실패 : 닉네임 중복)</h3>
+<div class="sect3">
+<h4 id="_request_13">Request</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/register/duplicate/nickname?nickname=testNickname HTTP/1.1
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_13">Response</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 400 Bad Request
+Content-Type: application/json
+Content-Length: 47
+
+{"message":"사용 중인 닉네임이에요!"}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">에러 메시지</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_회원가입_성공">회원가입 (성공)</h3>
+<div class="sect3">
+<h4 id="_request_14">Request</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/register HTTP/1.1
+Content-Type: application/json
+Content-Length: 260
+Host: localhost:8080
+
+{"studentId":"202023604","department":"COMPUTER","yearOfAdmission":2020,"nickname":"testNickname","password":"testPassword","phoneNumber":"010-1234-5678","marketingAgree":true,"accountHolder":"testAccountHolder","accountBank":"KB","accountNumber":"1234567890"}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>studentId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">학번</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>department</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">학과</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>yearOfAdmission</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">입학년도</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">닉네임</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>password</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">비밀번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>phoneNumber</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">전화번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>marketingAgree</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">마케팅 동의 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>accountHolder</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">계좌주</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>accountBank</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">은행</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>accountNumber</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">계좌번호</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_response_14">Response</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK</code></pre>
+</div>
+</div>
+</div>
+</div>
 </div>
 </div>
 </div>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-08-31 18:45:36 +0900
+Last updated 2023-09-11 02:36:55 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/main/resources/static/docs/usedBook.html
+++ b/src/main/resources/static/docs/usedBook.html
@@ -484,7 +484,7 @@ Host: localhost:8080</code></pre>
 Content-Type: application/json
 Content-Length: 307
 
-[{"imageUrl":"imageUrl","bookStatus":"SALE","name":"책이름","tradeAvailableDate":"2023-08-31","createdAt":"2023-08-31T18:45:40.082428","price":10000},{"imageUrl":"imageUrl","bookStatus":"TRADE","name":"책이름","tradeAvailableDate":"2023-08-31","createdAt":"2023-08-31T18:45:40.082439","price":100000}]</code></pre>
+[{"imageUrl":"imageUrl","bookStatus":"SALE","name":"책이름","tradeAvailableDate":"2023-09-11","createdAt":"2023-09-11T02:37:03.324365","price":10000},{"imageUrl":"imageUrl","bookStatus":"TRADE","name":"책이름","tradeAvailableDate":"2023-09-11","createdAt":"2023-09-11T02:37:03.324377","price":100000}]</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
@@ -586,7 +586,7 @@ Host: localhost:8080</code></pre>
 Content-Type: application/json
 Content-Length: 306
 
-[{"imageUrl":"imageUrl","bookStatus":"SALE","name":"책이름","tradeAvailableDate":"2023-08-31","createdAt":"2023-08-31T18:45:40.17181","price":10000},{"imageUrl":"imageUrl","bookStatus":"TRADE","name":"책이름","tradeAvailableDate":"2023-08-31","createdAt":"2023-08-31T18:45:40.171815","price":100000}]</code></pre>
+[{"imageUrl":"imageUrl","bookStatus":"SALE","name":"책이름","tradeAvailableDate":"2023-09-11","createdAt":"2023-09-11T02:37:03.41814","price":10000},{"imageUrl":"imageUrl","bookStatus":"TRADE","name":"책이름","tradeAvailableDate":"2023-09-11","createdAt":"2023-09-11T02:37:03.418145","price":100000}]</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">

--- a/src/test/java/team/dankookie/server4983/member/controller/MemberLoginControllerTest.java
+++ b/src/test/java/team/dankookie/server4983/member/controller/MemberLoginControllerTest.java
@@ -1,6 +1,5 @@
 package team.dankookie.server4983.member.controller;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.restdocs.cookies.CookieDocumentation;
@@ -9,13 +8,14 @@ import org.springframework.test.web.servlet.ResultActions;
 import team.dankookie.server4983.common.BaseControllerTest;
 import team.dankookie.server4983.common.exception.ErrorResponse;
 import team.dankookie.server4983.common.exception.LoginFailedException;
+import team.dankookie.server4983.jwt.service.RefreshTokenService;
+import team.dankookie.server4983.member.domain.Member;
 import team.dankookie.server4983.member.dto.LoginRequest;
 import team.dankookie.server4983.member.service.MemberService;
 
-import java.nio.charset.StandardCharsets;
-
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
@@ -29,6 +29,8 @@ class MemberLoginControllerTest extends BaseControllerTest {
 
     @MockBean
     MemberService memberService;
+    @MockBean
+    RefreshTokenService refreshTokenService;
 
     @Test
     void 로그인시_accessToken과_refreshToken을_리턴한다() throws Exception {
@@ -40,6 +42,8 @@ class MemberLoginControllerTest extends BaseControllerTest {
 
         when(memberService.login(loginRequest))
                 .thenReturn(true);
+        when(memberService.findMemberNicknameByStudentId(any()))
+                .thenReturn(Member.builder().nickname("nickname").studentId("studentId").password("password").build());
 
         //when
         ResultActions resultActions = mockMvc.perform(post(loginUrl)

--- a/src/test/java/team/dankookie/server4983/member/controller/MemberRegisterControllerTest.java
+++ b/src/test/java/team/dankookie/server4983/member/controller/MemberRegisterControllerTest.java
@@ -1,0 +1,164 @@
+package team.dankookie.server4983.member.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.ResultActions;
+import team.dankookie.server4983.book.constant.Department;
+import team.dankookie.server4983.common.BaseControllerTest;
+import team.dankookie.server4983.member.constant.AccountBank;
+import team.dankookie.server4983.member.domain.Member;
+import team.dankookie.server4983.member.dto.MemberRegisterRequest;
+import team.dankookie.server4983.member.service.MemberService;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class MemberRegisterControllerTest extends BaseControllerTest {
+
+    @MockBean
+    private MemberService memberService;
+
+    @Test
+    void 학번이_중복이_아니면_200을_리턴한다() throws Exception {
+        //given
+        final String studentId = "202023604";
+
+        when(memberService.isStudentIdDuplicate(studentId))
+            .thenReturn(false);
+        //when
+        ResultActions resultActions = mockMvc.perform(get(API + "/register/duplicate/studentId")
+                        .param("studentId", studentId))
+                .andDo(print());
+
+        //then
+        resultActions.andExpect(status().isOk())
+                .andDo(document("member-register/duplicate/studentId/success",
+                        queryParameters(
+                                parameterWithName("studentId").description("학번")
+                        )
+                ));
+    }
+
+    @Test
+    void 학번이_중복이면_400_에러와_에러메시지를_리턴한다() throws Exception {
+        //given
+        final String studentId = "202023604";
+
+        when(memberService.isStudentIdDuplicate(studentId))
+                .thenReturn(true);
+        //when
+        ResultActions resultActions = mockMvc.perform(get(API + "/register/duplicate/studentId")
+                        .param("studentId", studentId))
+                .andDo(print());
+
+        //then
+        resultActions.andExpect(status().isBadRequest())
+                .andDo(document("member-register/duplicate/studentId/fail",
+                        queryParameters(
+                                parameterWithName("studentId").description("학번")
+                        ),
+                        responseFields(
+                                fieldWithPath("message").description("에러 메시지")
+                        )
+                ));
+    }
+    @Test
+    void 닉네임이_중복이_아니면_200과_메시지를_리턴한다() throws Exception {
+        //given
+        final String nickname = "testNickname";
+
+        when(memberService.isNicknameDuplicate(nickname))
+                .thenReturn(false);
+        //when
+        ResultActions resultActions = mockMvc.perform(get(API + "/register/duplicate/nickname")
+                        .param("nickname", nickname))
+                .andDo(print());
+
+        //then
+        resultActions.andExpect(status().isOk())
+                .andDo(document("member-register/duplicate/nickname/success",
+                        queryParameters(
+                                parameterWithName("nickname").description("닉네임")
+                        ),
+                        responseFields(
+                                fieldWithPath("message").description("성공 메시지")
+                        )
+                ));
+    }
+
+    @Test
+    void 닉네임이_중복이면_400과_에러메시지를_리턴한다() throws Exception {
+        //given
+        final String nickname = "testNickname";
+
+        when(memberService.isNicknameDuplicate(nickname))
+                .thenReturn(true);
+        //when
+        ResultActions resultActions = mockMvc.perform(get(API + "/register/duplicate/nickname")
+                        .param("nickname", nickname))
+                .andDo(print());
+
+        //then
+        resultActions.andExpect(status().isBadRequest())
+                .andDo(document("member-register/duplicate/nickname/fail",
+                        queryParameters(
+                                parameterWithName("nickname").description("닉네임")
+                        ),
+                        responseFields(
+                                fieldWithPath("message").description("에러 메시지")
+                        )
+                ));
+    }
+
+    @Test
+    void 멤버를_저장한다() throws Exception {
+        //given
+        MemberRegisterRequest request = MemberRegisterRequest.of(
+                "202023604",
+                Department.COMPUTER,
+                2020,
+                "testNickname",
+                "testPassword",
+                "010-1234-5678",
+                true,
+                "testAccountHolder",
+                AccountBank.KB,
+                "1234567890"
+        );
+
+        when(memberService.register(request))
+                .thenReturn(Member.builder().build());
+
+        //when
+        ResultActions resultActions = mockMvc.perform(post(API + "/register")
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print());
+
+        //then
+        resultActions.andExpect(status().isOk())
+                .andDo(document("member-register/success",
+                        requestFields(
+                                fieldWithPath("studentId").description("학번"),
+                                fieldWithPath("department").description("학과"),
+                                fieldWithPath("yearOfAdmission").description("입학년도"),
+                                fieldWithPath("nickname").description("닉네임"),
+                                fieldWithPath("password").description("비밀번호"),
+                                fieldWithPath("phoneNumber").description("전화번호"),
+                                fieldWithPath("marketingAgree").description("마케팅 동의 여부"),
+                                fieldWithPath("accountHolder").description("계좌주"),
+                                fieldWithPath("accountBank").description("은행"),
+                                fieldWithPath("accountNumber").description("계좌번호")
+                        )
+                ));
+    }
+    
+}

--- a/src/test/java/team/dankookie/server4983/member/service/MemberServiceTest.java
+++ b/src/test/java/team/dankookie/server4983/member/service/MemberServiceTest.java
@@ -94,10 +94,10 @@ class MemberServiceTest extends BaseServiceTest {
         when(memberRepository.findByStudentId(studentId))
                 .thenReturn(Optional.of(member));
         //when
-        String nickname = memberService.findMemberNicknameByStudentId(studentId);
+        Member findMember = memberService.findMemberNicknameByStudentId(studentId);
 
         //then
-        assertThat(nickname).isEqualTo(member.getNickname());
+        assertThat(findMember.getNickname()).isEqualTo(member.getNickname());
     }
 
     @Test


### PR DESCRIPTION
## ✔ 지라 이슈 번호
DAN-53

## 📒 작업 내용
- AccessToken 클래스로 accessToken 들고오는 로직 구현 
- 로그인 로직버그 수정 및 토큰 관련 오타 수정 
- 멤버 회원가입 로직 구현 ( 학번 중복 확인,닉네임 중복 확인,회원가입)

## 📢 리뷰어에게 하고 싶은 말
ex) 어디어디를 중점적으로 봐주세요 ...


## 📌 PR 전 체크 사항
- [x] base 브랜치가 **develop** 또는 **main** 브랜치로 되어있나요?
- [x] PR title에 PR Type을 표시해 두었나요? (feat:, fix:, refact: ...)
- [x] test가 모두 통과 되었나요? 