### PR TITLE
feat: 전공서적 삭제, 업데이트, 각 이미지 삭제 api 구현

### DIFF
--- a/src/docs/asciidoc/usedBook.adoc
+++ b/src/docs/asciidoc/usedBook.adoc
@@ -122,7 +122,7 @@ include::{snippets}/used-book/save/success/request-headers.adoc[]
 include::{snippets}/used-book/save/success/http-response.adoc[]
 include::{snippets}/used-book/save/success/response-fields.adoc[]
 
-=== Usedbook 상세 보기
+=== Usedbook 게시물 상세 보기
 
 ==== Request
 
@@ -134,7 +134,46 @@ include::{snippets}/used-book/detail/success/path-parameters.adoc[]
 include::{snippets}/used-book/detail/success/http-response.adoc[]
 include::{snippets}/used-book/detail/success/response-fields.adoc[]
 
+=== Usedbook 게시물 삭제
 
+==== Request
 
+include::{snippets}/used-book/delete/success/http-request.adoc[]
+include::{snippets}/used-book/delete/success/path-parameters.adoc[]
+==== RequestHeader
+include::{snippets}/used-book/delete/success/request-headers.adoc[]
 
+==== Response
+
+include::{snippets}/used-book/delete/success/http-response.adoc[]
+
+=== Usedbook 게시물 개별 이미지 삭제
+
+==== Request
+
+include::{snippets}/used-book/image/delete/success/http-request.adoc[]
+include::{snippets}/used-book/image/delete/success/path-parameters.adoc[]
+==== RequestHeader
+include::{snippets}/used-book/image/delete/success/request-headers.adoc[]
+
+==== Response
+
+include::{snippets}/used-book/image/delete/success/http-response.adoc[]
+
+=== Usedbook 게시물 수정
+
+==== Request
+
+include::{snippets}/used-book/update/success/http-request.adoc[]
+include::{snippets}/used-book/update/success/request-parts.adoc[]
+===== usedBook fields 요소  {usedBook : {}}
+include::{snippets}/used-book/update/success/request-part-usedBook-fields.adoc[]
+
+===== RequestHeader
+include::{snippets}/used-book/update/success/request-headers.adoc[]
+
+==== Response
+
+include::{snippets}/used-book/update/success/http-response.adoc[]
+include::{snippets}/used-book/update/success/response-fields.adoc[]
 

--- a/src/main/java/team/dankookie/server4983/book/controller/UsedBookController.java
+++ b/src/main/java/team/dankookie/server4983/book/controller/UsedBookController.java
@@ -37,4 +37,31 @@ public class UsedBookController {
         return ResponseEntity.ok().body(usedBookResponse);
     }
 
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteUsedBook(@PathVariable Long id, AccessToken accessToken) {
+        boolean isDeleted = usedBookService.deleteUsedBook(id, accessToken);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/{id}/image/{image}")
+    public ResponseEntity<Void> deleteUsedBookImage(@PathVariable Long id, @PathVariable String image, AccessToken accessToken) {
+        boolean isDeleted = usedBookService.deleteUsedBookImage(id, image);
+
+        return ResponseEntity.noContent().build();
+    }
+
+
+    @PostMapping("/{id}")
+    public ResponseEntity<UsedBookSaveResponse> updateUsedBook(
+            @PathVariable Long id,
+            @RequestPart(value = "fileList", required = false) List<MultipartFile> multipartFileList,
+            @RequestPart(value = "usedBook") UsedBookSaveRequest usedBookSaveRequest,
+            AccessToken accessToken
+    ) {
+        UsedBookSaveResponse usedBookResponse = usedBookService.updateUsedBook(id, multipartFileList, usedBookSaveRequest, accessToken);
+
+        return ResponseEntity.ok().body(usedBookResponse);
+    }
+
 }

--- a/src/main/java/team/dankookie/server4983/book/domain/UsedBook.java
+++ b/src/main/java/team/dankookie/server4983/book/domain/UsedBook.java
@@ -6,15 +6,14 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
 import team.dankookie.server4983.book.constant.BookStatus;
 import team.dankookie.server4983.book.constant.College;
 import team.dankookie.server4983.book.constant.Department;
+import team.dankookie.server4983.book.dto.UsedBookSaveRequest;
 import team.dankookie.server4983.common.domain.BaseEntity;
 import team.dankookie.server4983.member.domain.Member;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -53,17 +52,33 @@ public class UsedBook extends BaseEntity {
     @Column(columnDefinition = "boolean default false")
     private Boolean isCoverDamaged;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @ManyToOne(fetch = FetchType.LAZY)
     private Member buyerMember;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
     private Member sellerMember;
 
-    @CreatedDate
-    private LocalDateTime createdAt;
+    @Column(columnDefinition = "boolean default false")
+    private Boolean isDeleted;
+
+    public void setIsDeletedTrue() {
+        isDeleted = true;
+    }
+
+    public void updateUsedBook(UsedBookSaveRequest usedBook) {
+        this.name = usedBook.name();
+        this.price = usedBook.price();
+        this.tradeAvailableDate = usedBook.tradeAvailableDate();
+        this.publisher = usedBook.publisher();
+        this.college = usedBook.college();
+        this.department = usedBook.department();
+        this.isUnderlinedOrWrite = usedBook.isUnderlinedOrWrite();
+        this.isDiscolorationAndDamage = usedBook.isDiscolorationAndDamage();
+        this.isCoverDamaged = usedBook.isCoverDamaged();
+    }
 
     @Builder
-    public UsedBook(Long id,String name, Integer price, LocalDate tradeAvailableDate, String publisher, College college, Department department, BookStatus bookStatus, Boolean isUnderlinedOrWrite, Boolean isDiscolorationAndDamage, Boolean isCoverDamaged, Member buyerMember, Member sellerMember) {
+    public UsedBook(Long id, String name, Integer price, LocalDate tradeAvailableDate, String publisher, College college, Department department, BookStatus bookStatus, Boolean isUnderlinedOrWrite, Boolean isDiscolorationAndDamage, Boolean isCoverDamaged, Member buyerMember, Member sellerMember, boolean isDeleted) {
         this.id = id;
         this.name = name;
         this.price = price;
@@ -77,13 +92,14 @@ public class UsedBook extends BaseEntity {
         this.isCoverDamaged = isCoverDamaged;
         this.buyerMember = buyerMember;
         this.sellerMember = sellerMember;
+        this.isDeleted = isDeleted;
     }
 
-    @Builder
-    public UsedBook(String name, Integer price, LocalDate tradeAvailableDate, String publisher, College college, Department department, BookStatus bookStatus, Boolean isUnderlinedOrWrite, Boolean isDiscolorationAndDamage, Boolean isCoverDamaged, Member buyerMember, Member sellerMember) {
-        this.name = name;
+    public UsedBook(long id, String bookName, int price, LocalDate now, String publisher, College college, Department department, BookStatus bookStatus, boolean isUnderlinedOrWrite, boolean isDiscolorationAndDamage, boolean isCoverDamaged, Member buyer, Member seller) {
+        this.id = id;
+        this.name = bookName;
         this.price = price;
-        this.tradeAvailableDate = tradeAvailableDate;
+        this.tradeAvailableDate = now;
         this.publisher = publisher;
         this.college = college;
         this.department = department;
@@ -91,7 +107,8 @@ public class UsedBook extends BaseEntity {
         this.isUnderlinedOrWrite = isUnderlinedOrWrite;
         this.isDiscolorationAndDamage = isDiscolorationAndDamage;
         this.isCoverDamaged = isCoverDamaged;
-        this.buyerMember = buyerMember;
-        this.sellerMember = sellerMember;
+        this.buyerMember = buyer;
+        this.sellerMember = seller;
     }
+
 }

--- a/src/main/java/team/dankookie/server4983/book/repository/bookImage/BookImageRepository.java
+++ b/src/main/java/team/dankookie/server4983/book/repository/bookImage/BookImageRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 
 public interface BookImageRepository extends JpaRepository<BookImage, Long> , BookImageRepositoryCustom{
     List<BookImage> findByUsedBook(UsedBook usedBook);
+
+    long deleteBookImageByUsedBookAndImageUrl(UsedBook usedBook,String imageUrl);
 }

--- a/src/main/java/team/dankookie/server4983/book/repository/usedBook/UsedBookRepository.java
+++ b/src/main/java/team/dankookie/server4983/book/repository/usedBook/UsedBookRepository.java
@@ -2,6 +2,9 @@ package team.dankookie.server4983.book.repository.usedBook;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import team.dankookie.server4983.book.domain.UsedBook;
+import team.dankookie.server4983.member.domain.Member;
 
 public interface UsedBookRepository extends JpaRepository<UsedBook, Long>, UsedBookRepositoryCustom {
+
+    boolean existsUsedBookByIdAndSellerMember(Long id, Member member);
 }

--- a/src/main/java/team/dankookie/server4983/book/repository/usedBook/UsedBookRepositoryImpl.java
+++ b/src/main/java/team/dankookie/server4983/book/repository/usedBook/UsedBookRepositoryImpl.java
@@ -35,7 +35,7 @@ public class UsedBookRepositoryImpl implements UsedBookRepositoryCustom {
     private List<UsedBook> getUsedBooksCanBuyElseAll(boolean canBuyElseAll, JPAQuery<UsedBook> query) {
         if (canBuyElseAll) {
             return query
-                    .where(usedBook.bookStatus.eq(BookStatus.SALE))
+                    .where(usedBook.bookStatus.eq(BookStatus.SALE).and(usedBook.isDeleted.eq(false)))
                     .orderBy(usedBook.createdAt.desc()).fetch();
         }else {
             return query

--- a/src/main/java/team/dankookie/server4983/book/service/UsedBookService.java
+++ b/src/main/java/team/dankookie/server4983/book/service/UsedBookService.java
@@ -35,7 +35,7 @@ public class UsedBookService {
     @Transactional
     public UsedBookSaveResponse saveAndSaveFiles(List<MultipartFile> multipartFileList, UsedBookSaveRequest usedBookSaveRequest, AccessToken accessToken) {
 
-        String nickname = jwtTokenUtils.getNickname(accessToken.value(), tokenSecretKey.getSecretKey());
+        String nickname = getNicknameWithAccessToken(accessToken);
         Member member = memberService.findMemberByNickname(nickname);
 
         UsedBook usedBook = usedBookRepository.save(usedBookSaveRequest.toEntity(member));
@@ -53,8 +53,7 @@ public class UsedBookService {
 
     public UsedBookResponse findByUsedBookId(Long id) {
 
-        UsedBook usedBook = usedBookRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("id와 일치하는 중고책이 존재하지 않습니다."));
+        UsedBook usedBook = getUsedBookById(id);
 
         List<BookImage> bookImageList = bookImageRepository.findByUsedBook(usedBook);
 
@@ -78,5 +77,72 @@ public class UsedBookService {
                 usedBook.getPrice(),
                 usedBook.getBookStatus()
         );
+    }
+
+    @Transactional
+    public boolean deleteUsedBook(Long id, AccessToken accessToken) {
+
+        String nickname = getNicknameWithAccessToken(accessToken);
+
+        Member member = memberService.findMemberByNickname(nickname);
+
+        boolean isUsedBookSavedByThisMember = usedBookRepository.existsUsedBookByIdAndSellerMember(id, member);
+
+        if (!isUsedBookSavedByThisMember) {
+            throw new IllegalArgumentException("글을 올린 사용자만 삭제할 수 있습니다.");
+        }
+
+        UsedBook usedBook = getUsedBookById(id);
+        usedBook.setIsDeletedTrue();
+
+        return true;
+    }
+
+    @Transactional
+    public boolean deleteUsedBookImage(Long id, String image) {
+        UsedBook usedBook = getUsedBookById(id);
+
+        String imageUrl = uploadService.s3Bucket + image;
+
+        long deleteCount = bookImageRepository.deleteBookImageByUsedBookAndImageUrl(usedBook, imageUrl);
+        if (deleteCount == 0) {
+            return false;
+        }
+
+        uploadService.deleteFile(image);
+        return true;
+    }
+
+    @Transactional
+    public UsedBookSaveResponse updateUsedBook(Long id, List<MultipartFile> multipartFileList, UsedBookSaveRequest usedBookSaveRequest, AccessToken accessToken) {
+        String nickname = getNicknameWithAccessToken(accessToken);
+        Member member = memberService.findMemberByNickname(nickname);
+
+        UsedBook usedBook = getUsedBookById(id);
+
+        if (!usedBook.getSellerMember().equals(member)) {
+            throw new IllegalArgumentException("글을 올린 유저만 수정할 수 있습니다.");
+        }
+
+        usedBook.updateUsedBook(usedBookSaveRequest);
+
+        for (MultipartFile multipartFile : multipartFileList) {
+            S3Response s3Response = uploadService.saveFileWithUUID(multipartFile);
+            BookImage bookImage = BookImage.builder()
+                    .usedBook(usedBook)
+                    .imageUrl(s3Response.s3ImageUrl()).build();
+            bookImageRepository.save(bookImage);
+        }
+
+        return UsedBookSaveResponse.of(usedBook.getId());    }
+
+    private String getNicknameWithAccessToken(AccessToken accessToken) {
+        String nickname = jwtTokenUtils.getNickname(accessToken.value(), tokenSecretKey.getSecretKey());
+        return nickname;
+    }
+
+    private UsedBook getUsedBookById(Long id) {
+        return usedBookRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("id와 일치하는 중고책이 존재하지 않습니다."));
     }
 }

--- a/src/main/java/team/dankookie/server4983/s3/service/S3UploadService.java
+++ b/src/main/java/team/dankookie/server4983/s3/service/S3UploadService.java
@@ -23,6 +23,8 @@ public class S3UploadService {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
+    public String s3Bucket = "https://4983-s3.s3.ap-northeast-2.amazonaws.com/";
+
     public S3Response saveFileWithUUID(MultipartFile multipartFile) {
         try {
             String originalFilename = multipartFile.getOriginalFilename();
@@ -37,6 +39,10 @@ public class S3UploadService {
             throw new RuntimeException(e);
         }
 
+    }
+
+    public void deleteFile(String image) {
+        amazonS3.deleteObject(bucket, image);
     }
 
     private PutObjectResult saveImageWithUUID(MultipartFile multipartFile, ObjectMetadata metadata, String uuid) throws IOException {

--- a/src/main/resources/static/docs/member.html
+++ b/src/main/resources/static/docs/member.html
@@ -523,8 +523,8 @@ Host: localhost:8080
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Authorization: eyJhbGciOiJIUzI1NiJ9.eyJuaWNrbmFtZSI6Im5pY2tuYW1lIiwiaWF0IjoxNjk0NjEyMDQ0LCJleHAiOjE2OTQ2MTM4NDR9.OHu3blWLjsOSyfTfLaFjv5MKfJ4GjrPV0S5xNNRMAl0
-Set-Cookie: refreshToken=eyJhbGciOiJIUzI1NiJ9.eyJuaWNrbmFtZSI6Im5pY2tuYW1lIiwiaWF0IjoxNjk0NjEyMDQ0LCJleHAiOjE2OTU4MjE2NDR9.ChzI42MbcA1sH9vQveN5njP_si6X3GL1Lp7SgVAxEOk</code></pre>
+Authorization: eyJhbGciOiJIUzI1NiJ9.eyJuaWNrbmFtZSI6Im5pY2tuYW1lIiwiaWF0IjoxNjk0Nzg3MTQzLCJleHAiOjE2OTQ3ODg5NDN9.igjvuSV_xw_RLh2B65oeFQUU2oH89exp9uMJ_bEvm8g
+Set-Cookie: refreshToken=eyJhbGciOiJIUzI1NiJ9.eyJuaWNrbmFtZSI6Im5pY2tuYW1lIiwiaWF0IjoxNjk0Nzg3MTQzLCJleHAiOjE2OTU5OTY3NDN9.yRCKdt4ogXU6JiunPdVQBEc33TOhGZlHmLL4P1N_Wug</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -1706,7 +1706,7 @@ Host: localhost:8080
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/college-department HTTP/1.1
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJuaWNrbmFtZSI6Im5pY2tuYW1lIiwiaWF0IjoxNjk0NjEyMDQ1LCJleHAiOjE2OTQ2MTM4NDV9.WaiU1zW_QmA7yfjsAGINnCl_cKux3u65VruTITt8Y_Q
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJuaWNrbmFtZSI6Im5pY2tuYW1lIiwiaWF0IjoxNjk0Nzg3MTQzLCJleHAiOjE2OTQ3ODg5NDN9.igjvuSV_xw_RLh2B65oeFQUU2oH89exp9uMJ_bEvm8g
 Host: localhost:8080</code></pre>
 </div>
 </div>

--- a/src/main/resources/static/docs/usedBook.html
+++ b/src/main/resources/static/docs/usedBook.html
@@ -450,7 +450,10 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_단과대_학과에_따라_서적_리스트_가져오기">단과대 학과에 따라 서적 리스트 가져오기</a></li>
 <li><a href="#_usedbook_글쓰기_관련_문서">UsedBook 글쓰기 관련 문서</a></li>
 <li><a href="#_usedbook_글_저장">UsedBook 글 저장</a></li>
-<li><a href="#_usedbook_상세_보기">Usedbook 상세 보기</a></li>
+<li><a href="#_usedbook_게시물_상세_보기">Usedbook 게시물 상세 보기</a></li>
+<li><a href="#_usedbook_게시물_삭제">Usedbook 게시물 삭제</a></li>
+<li><a href="#_usedbook_게시물_개별_이미지_삭제">Usedbook 게시물 개별 이미지 삭제</a></li>
+<li><a href="#_usedbook_게시물_수정">Usedbook 게시물 수정</a></li>
 </ul>
 </li>
 </ul>
@@ -485,9 +488,9 @@ Host: localhost:8080</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json
-Content-Length: 307
+Content-Length: 306
 
-[{"imageUrl":"imageUrl","bookStatus":"SALE","name":"책이름","tradeAvailableDate":"2023-09-13","createdAt":"2023-09-13T22:34:03.426188","price":10000},{"imageUrl":"imageUrl","bookStatus":"TRADE","name":"책이름","tradeAvailableDate":"2023-09-13","createdAt":"2023-09-13T22:34:03.426207","price":100000}]</code></pre>
+[{"imageUrl":"imageUrl","bookStatus":"SALE","name":"책이름","tradeAvailableDate":"2023-09-15","createdAt":"2023-09-15T23:12:22.11123","price":10000},{"imageUrl":"imageUrl","bookStatus":"TRADE","name":"책이름","tradeAvailableDate":"2023-09-15","createdAt":"2023-09-15T23:12:22.111241","price":100000}]</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
@@ -589,7 +592,7 @@ Host: localhost:8080</code></pre>
 Content-Type: application/json
 Content-Length: 307
 
-[{"imageUrl":"imageUrl","bookStatus":"SALE","name":"책이름","tradeAvailableDate":"2023-09-13","createdAt":"2023-09-13T22:34:03.442689","price":10000},{"imageUrl":"imageUrl","bookStatus":"TRADE","name":"책이름","tradeAvailableDate":"2023-09-13","createdAt":"2023-09-13T22:34:03.442695","price":100000}]</code></pre>
+[{"imageUrl":"imageUrl","bookStatus":"SALE","name":"책이름","tradeAvailableDate":"2023-09-15","createdAt":"2023-09-15T23:12:22.124629","price":10000},{"imageUrl":"imageUrl","bookStatus":"TRADE","name":"책이름","tradeAvailableDate":"2023-09-15","createdAt":"2023-09-15T23:12:22.124633","price":100000}]</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
@@ -747,7 +750,7 @@ GUGAK("국악전공", MUSIC_AND_ARTS);</pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/used-book HTTP/1.1
 Content-Type: multipart/form-data; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJuaWNrbmFtZSI6Im5pY2tuYW1lIiwiaWF0IjoxNjk0NjEyMDQyLCJleHAiOjE2OTQ2MTIwNDN9.SxR44OX0_O_mx-c0IyZDF7LuE7Sq1OtSBMGpR9s0GqI
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJuaWNrbmFtZSI6Im5pY2tuYW1lIiwiaWF0IjoxNjk0Nzg3MTQxLCJleHAiOjE2OTQ3ODcxNDJ9.W_oDi2VkE0Xu5YCiNaFuFjX3X1M99n787PqfD5R0gJQ
 Host: localhost:8080
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
@@ -921,7 +924,7 @@ Content-Length: 16
 </div>
 </div>
 <div class="sect2">
-<h3 id="_usedbook_상세_보기">Usedbook 상세 보기</h3>
+<h3 id="_usedbook_게시물_상세_보기">Usedbook 게시물 상세 보기</h3>
 <div class="sect3">
 <h4 id="_request_4">Request</h4>
 <div class="listingblock">
@@ -1049,13 +1052,320 @@ Content-Length: 378
 </table>
 </div>
 </div>
+<div class="sect2">
+<h3 id="_usedbook_게시물_삭제">Usedbook 게시물 삭제</h3>
+<div class="sect3">
+<h4 id="_request_5">Request</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/used-book/1 HTTP/1.1
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJuaWNrbmFtZSI6Im5pY2tuYW1lIiwiaWF0IjoxNjk0Nzg3MTQxLCJleHAiOjE2OTQ3ODcxNDJ9.W_oDi2VkE0Xu5YCiNaFuFjX3X1M99n787PqfD5R0gJQ
+Host: localhost:8080</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 2. /api/v1/used-book/{id}</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">중고서적 id</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_requestheader_2">RequestHeader</h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_response_5">Response</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 204 No Content</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_usedbook_게시물_개별_이미지_삭제">Usedbook 게시물 개별 이미지 삭제</h3>
+<div class="sect3">
+<h4 id="_request_6">Request</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/used-book/1/image/image.png HTTP/1.1
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJuaWNrbmFtZSI6Im5pY2tuYW1lIiwiaWF0IjoxNjk0Nzg3MTQxLCJleHAiOjE2OTQ3ODcxNDJ9.W_oDi2VkE0Xu5YCiNaFuFjX3X1M99n787PqfD5R0gJQ
+Host: localhost:8080</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 3. /api/v1/used-book/{id}/image/{image}</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">중고서적 id</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>image</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><a href="https://4983-s3.s3.ap-northeast-2.amazonaws.com/" class="bare">https://4983-s3.s3.ap-northeast-2.amazonaws.com/</a> 이후의 이미지 명</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_requestheader_3">RequestHeader</h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_response_6">Response</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 204 No Content</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_usedbook_게시물_수정">Usedbook 게시물 수정</h3>
+<div class="sect3">
+<h4 id="_request_7">Request</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/used-book/1 HTTP/1.1
+Content-Type: multipart/form-data; boundary=6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJuaWNrbmFtZSI6Im5pY2tuYW1lIiwiaWF0IjoxNjk0Nzg3MTQxLCJleHAiOjE2OTQ3ODcxNDJ9.W_oDi2VkE0Xu5YCiNaFuFjX3X1M99n787PqfD5R0gJQ
+Host: localhost:8080
+
+--6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
+Content-Disposition: form-data; name=fileList; filename=file1.png
+Content-Type: multipart/form-data
+
+file1
+--6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
+Content-Disposition: form-data; name=fileList; filename=file2.png
+Content-Type: multipart/form-data
+
+file2
+--6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
+Content-Disposition: form-data; name=fileList; filename=file3.png
+Content-Type: multipart/form-data
+
+file3
+--6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
+Content-Disposition: form-data; name=fileList; filename=file4.png
+Content-Type: multipart/form-data
+
+file4
+--6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
+Content-Disposition: form-data; name=usedBook
+Content-Type: application/json
+
+{"college":"LAW","department":"BUSINESS","price":15000,"tradeAvailableDate":"2023-09-13","name":"책이름","publisher":"출판사","isUnderlinedOrWrite":false,"isDiscolorationAndDamage":true,"isCoverDamaged":true}
+--6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm--</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Part</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>fileList</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">새로 저장할 이미지 리스트</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>usedBook</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">중고서적 정보</p></td>
+</tr>
+</tbody>
+</table>
+<div class="sect4">
+<h5 id="_usedbook_fields_요소_usedbook_2">usedBook fields 요소  {usedBook : {}}</h5>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>college</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">단과대</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>department</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">학과</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>price</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">가격</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>tradeAvailableDate</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">거래 가능 날짜</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>name</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">책 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>publisher</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">출판사</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>isUnderlinedOrWrite</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">밑줄및 필기흔적 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>isDiscolorationAndDamage</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">페이지 변색 및 훼손 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>isCoverDamaged</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">겉표지 훼손 여부</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect4">
+<h5 id="_requestheader_4">RequestHeader</h5>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">accessToken</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_7">Response</h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 16
+
+{"usedBookId":1}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>usedBookId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">중고서적 id</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
 </div>
 </div>
 </div>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-09-13 22:32:46 +0900
+Last updated 2023-09-15 23:12:13 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/test/java/team/dankookie/server4983/book/repository/usedBook/UsedBookRepositoryTest.java
+++ b/src/test/java/team/dankookie/server4983/book/repository/usedBook/UsedBookRepositoryTest.java
@@ -1,6 +1,7 @@
 package team.dankookie.server4983.book.repository.usedBook;
 
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import team.dankookie.server4983.book.constant.BookStatus;
@@ -10,6 +11,7 @@ import team.dankookie.server4983.book.domain.UsedBook;
 import team.dankookie.server4983.common.BaseRepositoryTest;
 import team.dankookie.server4983.member.constant.AccountBank;
 import team.dankookie.server4983.member.domain.Member;
+import team.dankookie.server4983.member.fixture.MemberFixture;
 import team.dankookie.server4983.member.repository.MemberRepository;
 
 import java.time.LocalDate;
@@ -25,6 +27,12 @@ class UsedBookRepositoryTest extends BaseRepositoryTest {
 
     @Autowired
     MemberRepository memberRepository;
+
+    @BeforeEach
+    void setUp() {
+        usedBookRepository.deleteAll();
+        memberRepository.deleteAll();
+    }
 
     @Test
     void 모든_서적을_리턴한다() {
@@ -47,7 +55,7 @@ class UsedBookRepositoryTest extends BaseRepositoryTest {
 
         UsedBook usedBookSale = UsedBook.builder()
                 .bookStatus(BookStatus.SALE)
-                .buyerMember(member)
+                .sellerMember(member)
                 .tradeAvailableDate(LocalDate.now())
                 .price(10000)
                 .name("책이름")
@@ -55,7 +63,7 @@ class UsedBookRepositoryTest extends BaseRepositoryTest {
 
         UsedBook usedBookTrade = UsedBook.builder()
                 .bookStatus(BookStatus.TRADE)
-                .buyerMember(member)
+                .sellerMember(member)
                 .tradeAvailableDate(LocalDate.now())
                 .price(10000)
                 .name("책이름")
@@ -63,7 +71,7 @@ class UsedBookRepositoryTest extends BaseRepositoryTest {
 
         UsedBook usedBookSold = UsedBook.builder()
                 .bookStatus(BookStatus.SOLD)
-                .buyerMember(member)
+                .sellerMember(member)
                 .tradeAvailableDate(LocalDate.now())
                 .price(10000)
                 .name("책이름")
@@ -112,7 +120,7 @@ class UsedBookRepositoryTest extends BaseRepositoryTest {
                 .college(collegeList.get(0))
                 .department(departmentList.get(0))
                 .bookStatus(BookStatus.SALE)
-                .buyerMember(member)
+                .sellerMember(member)
                 .tradeAvailableDate(LocalDate.now())
                 .price(10000)
                 .name("책이름")
@@ -122,7 +130,7 @@ class UsedBookRepositoryTest extends BaseRepositoryTest {
                 .college(collegeList.get(0))
                 .department(departmentList.get(0))
                 .bookStatus(BookStatus.SALE)
-                .buyerMember(member)
+                .sellerMember(member)
                 .tradeAvailableDate(LocalDate.now())
                 .price(10000)
                 .name("책이름")
@@ -131,7 +139,7 @@ class UsedBookRepositoryTest extends BaseRepositoryTest {
         UsedBook usedBookElse = UsedBook.builder()
                 .college(College.BUSINESS_AND_ECONOMICS)
                 .department(Department.ACCOUNTING)
-                .buyerMember(member)
+                .sellerMember(member)
                 .tradeAvailableDate(LocalDate.now())
                 .bookStatus(BookStatus.SALE)
                 .price(10000)
@@ -177,7 +185,7 @@ class UsedBookRepositoryTest extends BaseRepositoryTest {
                 .college(collegeList.get(0))
                 .department(departmentList.get(0))
                 .bookStatus(BookStatus.SALE)
-                .buyerMember(member)
+                .sellerMember(member)
                 .tradeAvailableDate(LocalDate.now())
                 .price(10000)
                 .name("책이름")
@@ -187,7 +195,7 @@ class UsedBookRepositoryTest extends BaseRepositoryTest {
                 .college(collegeList.get(0))
                 .department(departmentList.get(0))
                 .bookStatus(BookStatus.SALE)
-                .buyerMember(member)
+                .sellerMember(member)
                 .tradeAvailableDate(LocalDate.now())
                 .price(10000)
                 .name("책이름")
@@ -196,7 +204,7 @@ class UsedBookRepositoryTest extends BaseRepositoryTest {
         UsedBook usedBookElse = UsedBook.builder()
                 .college(College.BUSINESS_AND_ECONOMICS)
                 .department(Department.ACCOUNTING)
-                .buyerMember(member)
+                .sellerMember(member)
                 .tradeAvailableDate(LocalDate.now())
                 .bookStatus(BookStatus.SALE)
                 .price(10000)
@@ -242,7 +250,7 @@ class UsedBookRepositoryTest extends BaseRepositoryTest {
                 .college(collegeList.get(0))
                 .department(departmentList.get(0))
                 .bookStatus(BookStatus.SALE)
-                .buyerMember(member)
+                .sellerMember(member)
                 .tradeAvailableDate(LocalDate.now())
                 .price(10000)
                 .name("책이름")
@@ -252,7 +260,7 @@ class UsedBookRepositoryTest extends BaseRepositoryTest {
                 .college(collegeList.get(0))
                 .department(departmentList.get(0))
                 .bookStatus(BookStatus.SALE)
-                .buyerMember(member)
+                .sellerMember(member)
                 .tradeAvailableDate(LocalDate.now())
                 .price(10000)
                 .name("책이름")
@@ -261,7 +269,7 @@ class UsedBookRepositoryTest extends BaseRepositoryTest {
         UsedBook usedBookElse = UsedBook.builder()
                 .college(College.BUSINESS_AND_ECONOMICS)
                 .department(Department.ACCOUNTING)
-                .buyerMember(member)
+                .sellerMember(member)
                 .tradeAvailableDate(LocalDate.now())
                 .bookStatus(BookStatus.SALE)
                 .price(10000)
@@ -281,5 +289,50 @@ class UsedBookRepositoryTest extends BaseRepositoryTest {
         assertThat(usedBookList).hasSize(2);
     }
 
+    @Test
+    void 해당_서적과_올린_판매자가_일치하면_true를_리턴한다() {
+        //given
+        Member member = MemberFixture.createMember();
+        memberRepository.save(member);
+
+        UsedBook usedBook = UsedBook.builder()
+                .bookStatus(BookStatus.SALE)
+                .tradeAvailableDate(LocalDate.now())
+                .price(10000)
+                .name("책이름")
+                .sellerMember(member)
+                .build();
+        usedBookRepository.save(usedBook);
+
+        //when
+        boolean isUsedBookSavedByThisMember = usedBookRepository.existsUsedBookByIdAndSellerMember(usedBook.getId(), member);
+
+        //then
+        assertThat(isUsedBookSavedByThisMember).isTrue();
+    }
+
+    @Test
+    void 해당_서적과_올린_판매자가_일치하지_않으면_false를_리턴한다() {
+        //given
+        Member member = MemberFixture.createMember();
+        Member notMatchMember = MemberFixture.createMemberByNickname("otherNickname");
+        memberRepository.save(member);
+        memberRepository.save(notMatchMember);
+
+        UsedBook usedBook = UsedBook.builder()
+                .bookStatus(BookStatus.SALE)
+                .tradeAvailableDate(LocalDate.now())
+                .price(10000)
+                .name("책이름")
+                .sellerMember(member)
+                .build();
+        usedBookRepository.save(usedBook);
+
+        //when
+        boolean isUsedBookSavedByThisMember = usedBookRepository.existsUsedBookByIdAndSellerMember(usedBook.getId(), notMatchMember);
+
+        //then
+        assertThat(isUsedBookSavedByThisMember).isFalse();
+    }
 
 }


### PR DESCRIPTION
## ✔ 지라 이슈 번호
DAN-68

## 📒 작업 내용
- 전공서적 리스트 softDelete 조건 추가
- 중고서적 판매 삭제 api, 중고서적 업데이트 api, 중고서적 이미지 삭제 api 구현

## 📢 리뷰어에게 하고 싶은 말
ex) 어디어디를 중점적으로 봐주세요 ...


## 📌 PR 전 체크 사항
- [x] base 브랜치가 **develop** 또는 **main** 브랜치로 되어있나요?
- [x] PR title에 PR Type을 표시해 두었나요? (feat:, fix:, refact: ...)
- [x] test가 모두 통과 되었나요? 