### PR TITLE
feat: 유저의 채팅방 리스트 api 구현

### DIFF
--- a/src/docs/asciidoc/chat.adoc
+++ b/src/docs/asciidoc/chat.adoc
@@ -1,0 +1,23 @@
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+
+== 메인 문서
+
+link:index.html[메인 문서]
+
+
+=== 유저의 채팅방 리스트 리턴 (성공)
+
+==== Request
+
+include::{snippets}/chat-list/success/http-request.adoc[]
+RequestHeader::
+include::{snippets}/chat-list/success/request-headers.adoc[]
+
+==== Response
+
+include::{snippets}/chat-list/success/http-response.adoc[]
+include::{snippets}/chat-list/success/response-fields.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -16,3 +16,7 @@
 == Member 문서
 
 * link:member.html[Member 문서]
+
+== Chat 문서
+
+* link:chat.html[Chat 문서]

--- a/src/main/java/team/dankookie/server4983/book/domain/UsedBook.java
+++ b/src/main/java/team/dankookie/server4983/book/domain/UsedBook.java
@@ -20,7 +20,6 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
-@Builder
 public class UsedBook extends BaseEntity {
 
     @Id @GeneratedValue
@@ -67,6 +66,7 @@ public class UsedBook extends BaseEntity {
     @OneToMany(mappedBy = "usedBook", cascade = CascadeType.ALL)
     private List<BookImage> bookImageList = new ArrayList<>();
 
+
     // FIXME 테스트 용 USEDBOOK 생성자 ( 테스트 데이터가 필요 없어진게 아니면 절대 수정하지 마세요!! )
     public UsedBook(long id, String bookName, int price, LocalDate now, String publisher, College college, Department department, BookStatus bookStatus, boolean isUnderlinedOrWrite, boolean isDiscolorationAndDamage, boolean isCoverDamaged, Member buyer, Member seller) {
         this.id = id;
@@ -88,6 +88,7 @@ public class UsedBook extends BaseEntity {
     public void setIsDeletedTrue() {
         isDeleted = true;
     }
+
     @Builder
     public UsedBook(Long id, String name, Integer price, LocalDate tradeAvailableDate, String publisher, College college, Department department, BookStatus bookStatus, Boolean isUnderlinedOrWrite, Boolean isDiscolorationAndDamage, Boolean isCoverDamaged, Member buyerMember, Member sellerMember, Boolean isDeleted) {
         this.id = id;

--- a/src/main/java/team/dankookie/server4983/book/domain/UsedBook.java
+++ b/src/main/java/team/dankookie/server4983/book/domain/UsedBook.java
@@ -14,6 +14,8 @@ import team.dankookie.server4983.common.domain.BaseEntity;
 import team.dankookie.server4983.member.domain.Member;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -61,6 +63,9 @@ public class UsedBook extends BaseEntity {
     @Column(columnDefinition = "boolean default false")
     private Boolean isDeleted;
 
+    @OneToMany(mappedBy = "usedBook", cascade = CascadeType.ALL)
+    private List<BookImage> bookImageList = new ArrayList<>();
+
     public UsedBook(long id, String bookName, int price, LocalDate now, String publisher, College college, Department department, BookStatus bookStatus, boolean isUnderlinedOrWrite, boolean isDiscolorationAndDamage, boolean isCoverDamaged, Member buyer, Member seller) {
         super();
     }
@@ -68,6 +73,7 @@ public class UsedBook extends BaseEntity {
     public void setIsDeletedTrue() {
         isDeleted = true;
     }
+
     @Builder
     public UsedBook(Long id, String name, Integer price, LocalDate tradeAvailableDate, String publisher, College college, Department department, BookStatus bookStatus, Boolean isUnderlinedOrWrite, Boolean isDiscolorationAndDamage, Boolean isCoverDamaged, Member buyerMember, Member sellerMember, Boolean isDeleted) {
         this.id = id;

--- a/src/main/java/team/dankookie/server4983/chat/controller/ChatListController.java
+++ b/src/main/java/team/dankookie/server4983/chat/controller/ChatListController.java
@@ -1,0 +1,24 @@
+package team.dankookie.server4983.chat.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import team.dankookie.server4983.chat.dto.ChatListResponse;
+import team.dankookie.server4983.chat.service.ChatService;
+import team.dankookie.server4983.jwt.dto.AccessToken;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class ChatListController {
+
+    private final ChatService chatService;
+
+    @GetMapping("/chat/list")
+    public List<ChatListResponse> getChatList(AccessToken accessToken) {
+        return chatService.getChatListWithAccessToken(accessToken);
+    }
+}

--- a/src/main/java/team/dankookie/server4983/chat/domain/BuyerChat.java
+++ b/src/main/java/team/dankookie/server4983/chat/domain/BuyerChat.java
@@ -39,10 +39,22 @@ public class BuyerChat {
     @CreationTimestamp
     private LocalDateTime createdAt;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_room_id")
+    private ChatRoom chatRoom;
+
     public static BuyerChat buildBuyerChat(String message , ContentType contentType) {
         return BuyerChat.builder()
                 .message(message)
                 .contentType(contentType)
+                .build();
+    }
+
+    public static BuyerChat buildBuyerChat(String message , ContentType contentType, ChatRoom chatRoom) {
+        return BuyerChat.builder()
+                .message(message)
+                .contentType(contentType)
+                .chatRoom(chatRoom)
                 .build();
     }
 

--- a/src/main/java/team/dankookie/server4983/chat/domain/SellerChat.java
+++ b/src/main/java/team/dankookie/server4983/chat/domain/SellerChat.java
@@ -38,10 +38,22 @@ public class SellerChat {
     @CreationTimestamp
     private LocalDateTime createdAt;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_room_id")
+    private ChatRoom chatRoom;
+
     public static SellerChat buildSellerChat(String message , ContentType contentType) {
         return SellerChat.builder()
                 .message(message)
                 .contentType(contentType)
+                .build();
+    }
+
+    public static SellerChat buildSellerChat(String message , ContentType contentType, ChatRoom chatRoom) {
+        return SellerChat.builder()
+                .message(message)
+                .contentType(contentType)
+                .chatRoom(chatRoom)
                 .build();
     }
 

--- a/src/main/java/team/dankookie/server4983/chat/dto/ChatListResponse.java
+++ b/src/main/java/team/dankookie/server4983/chat/dto/ChatListResponse.java
@@ -1,0 +1,16 @@
+package team.dankookie.server4983.chat.dto;
+
+import java.time.LocalDateTime;
+
+public record ChatListResponse(
+        String imageUrl,
+        String usedBookName,
+        String message,
+        LocalDateTime createdAt,
+        boolean isRead
+) {
+
+    public static ChatListResponse of(String imageUrl, String usedBookName, String message, LocalDateTime createdAt, boolean isRead) {
+        return new ChatListResponse(imageUrl, usedBookName, message, createdAt, isRead);
+    }
+}

--- a/src/main/java/team/dankookie/server4983/chat/dto/ChatListResponse.java
+++ b/src/main/java/team/dankookie/server4983/chat/dto/ChatListResponse.java
@@ -3,14 +3,28 @@ package team.dankookie.server4983.chat.dto;
 import java.time.LocalDateTime;
 
 public record ChatListResponse(
-        String imageUrl,
+    long chatRoomId,
+    String usedBookName,
+    String message,
+    LocalDateTime createdAt,
+    boolean isRead,
+    String imageUrl
+) {
+    public static ChatListResponse of(
+        long chatRoomId,
         String usedBookName,
         String message,
         LocalDateTime createdAt,
-        boolean isRead
-) {
-
-    public static ChatListResponse of(String imageUrl, String usedBookName, String message, LocalDateTime createdAt, boolean isRead) {
-        return new ChatListResponse(imageUrl, usedBookName, message, createdAt, isRead);
+        boolean isRead,
+        String imageUrl
+    ) {
+        return new ChatListResponse(
+            chatRoomId,
+            usedBookName,
+            message,
+            createdAt,
+            isRead,
+            imageUrl
+        );
     }
 }

--- a/src/main/java/team/dankookie/server4983/chat/repository/BuyerChatRepository.java
+++ b/src/main/java/team/dankookie/server4983/chat/repository/BuyerChatRepository.java
@@ -1,0 +1,7 @@
+package team.dankookie.server4983.chat.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team.dankookie.server4983.chat.domain.BuyerChat;
+
+public interface BuyerChatRepository extends JpaRepository<BuyerChat, Long> {
+}

--- a/src/main/java/team/dankookie/server4983/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/team/dankookie/server4983/chat/repository/ChatRoomRepository.java
@@ -2,6 +2,9 @@ package team.dankookie.server4983.chat.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import team.dankookie.server4983.chat.domain.ChatRoom;
+import team.dankookie.server4983.chat.dto.ChatListResponse;
+
+import java.util.List;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> , ChatRoomRepositoryCustom {
 

--- a/src/main/java/team/dankookie/server4983/chat/repository/ChatRoomRepositoryCustom.java
+++ b/src/main/java/team/dankookie/server4983/chat/repository/ChatRoomRepositoryCustom.java
@@ -1,8 +1,10 @@
 package team.dankookie.server4983.chat.repository;
 
+import team.dankookie.server4983.book.domain.UsedBook;
 import team.dankookie.server4983.chat.domain.BuyerChat;
 import team.dankookie.server4983.chat.domain.ChatRoom;
 import team.dankookie.server4983.chat.domain.SellerChat;
+import team.dankookie.server4983.chat.dto.ChatListResponse;
 import team.dankookie.server4983.member.domain.Member;
 
 import java.util.List;

--- a/src/main/java/team/dankookie/server4983/chat/repository/ChatRoomRepositoryCustom.java
+++ b/src/main/java/team/dankookie/server4983/chat/repository/ChatRoomRepositoryCustom.java
@@ -3,6 +3,7 @@ package team.dankookie.server4983.chat.repository;
 import team.dankookie.server4983.chat.domain.BuyerChat;
 import team.dankookie.server4983.chat.domain.ChatRoom;
 import team.dankookie.server4983.chat.domain.SellerChat;
+import team.dankookie.server4983.chat.dto.ChatListResponse;
 import team.dankookie.server4983.member.domain.Member;
 
 import java.util.List;
@@ -25,5 +26,7 @@ public interface ChatRoomRepositoryCustom {
     long modifyBuyerChattingToRead(long chatRoomId);
 
     Optional<ChatRoom> findChatRoomAndBookById(long chatRoomId);
+
+    List<ChatListResponse> findByChatroomWithNickname(String nickname);
 
 }

--- a/src/main/java/team/dankookie/server4983/chat/repository/ChatRoomRepositoryImpl.java
+++ b/src/main/java/team/dankookie/server4983/chat/repository/ChatRoomRepositoryImpl.java
@@ -1,19 +1,29 @@
 package team.dankookie.server4983.chat.repository;
 
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import team.dankookie.server4983.book.domain.UsedBook;
 import team.dankookie.server4983.chat.domain.BuyerChat;
 import team.dankookie.server4983.chat.domain.ChatRoom;
 import team.dankookie.server4983.chat.domain.SellerChat;
+import team.dankookie.server4983.chat.dto.ChatListResponse;
 import team.dankookie.server4983.member.domain.Member;
+import team.dankookie.server4983.member.domain.QMember;
 
-import static team.dankookie.server4983.member.domain.QMember.member;
-import static team.dankookie.server4983.chat.domain.QBuyerChat.buyerChat;
-import static team.dankookie.server4983.chat.domain.QSellerChat.sellerChat;
-import static team.dankookie.server4983.chat.domain.QChatRoom.chatRoom;
+import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
+
+import static team.dankookie.server4983.book.domain.QBookImage.bookImage;
+import static team.dankookie.server4983.book.domain.QUsedBook.usedBook;
+import static team.dankookie.server4983.chat.domain.QBuyerChat.buyerChat;
+import static team.dankookie.server4983.chat.domain.QChatRoom.chatRoom;
+import static team.dankookie.server4983.chat.domain.QSellerChat.sellerChat;
+import static team.dankookie.server4983.member.domain.QMember.member;
 
 @RequiredArgsConstructor
 public class ChatRoomRepositoryImpl implements ChatRoomRepositoryCustom {
@@ -115,43 +125,102 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryCustom {
 
         return Optional.ofNullable(result);
     }
+
     @Override
     public List<ChatListResponse> findByChatroomWithNickname(String nickname) {
-        List<ChatListResponse> chatInfoList = jpaQueryFactory
-                .select(Projections.constructor(ChatListResponse.class,
-                        chatRoom.usedBook.bookImageList.get(0).imageUrl,
-                        chatRoom.usedBook.name,
-                        chatRoom.buyerChats.get(0).message,
-                        chatRoom.buyerChats.get(0).createdAt,
-                        chatRoom.buyerChats.get(0).isRead
+        List<ChatListResponse> chatListResponseList = jpaQueryFactory
+                .select(
+                        Projections.constructor(
+                                ChatListResponse.class,
+                                chatRoom.chatRoomId,
+                                usedBook.name,
+                                getLastBuyerMessage(),
+                                getLastBuyerMessageCreatedAt(),
+                                getLastBuyerMessageIsRead(),
+                                getFirstUsedBookImageUrl()
                         ))
                 .from(chatRoom)
-                .innerJoin(chatRoom.buyerChats)
-                .innerJoin(chatRoom.usedBook).fetchJoin()
-                .where(
-                        chatRoom.buyer.nickname.eq(nickname)
-                )
-                .orderBy(chatRoom.buyerChats.get(0).createdAt.desc())
+                .join(chatRoom.usedBook, usedBook)
+                .where(chatRoom.buyer.nickname.eq(nickname))
                 .fetch();
 
-        chatInfoList.addAll(jpaQueryFactory
-                .select(Projections.constructor(ChatListResponse.class,
-                        chatRoom.usedBook.bookImageList.get(0).imageUrl,
-                        chatRoom.usedBook.name,
-                        chatRoom.buyerChats.get(0).message,
-                        chatRoom.buyerChats.get(0).createdAt,
-                        chatRoom.buyerChats.get(0).isRead
-                ))
+        chatListResponseList.addAll(jpaQueryFactory
+                .select(
+                        Projections.constructor(
+                                ChatListResponse.class,
+                                chatRoom.chatRoomId,
+                                usedBook.name,
+                                getLastSellerMessage(),
+                                getLastSellerMessageCreatedAt(),
+                                getLastSellerMessageIsRead(),
+                                getFirstUsedBookImageUrl()
+                        ))
                 .from(chatRoom)
-                .innerJoin(chatRoom.sellerChats)
-                .innerJoin(chatRoom.usedBook).fetchJoin()
-                .where(
-                        chatRoom.seller.nickname.eq(nickname)
-                )
-                .orderBy(chatRoom.sellerChats.any().createdAt.desc())
+                .join(chatRoom.usedBook, usedBook)
+                .where(chatRoom.seller.nickname.eq(nickname))
                 .fetch());
 
-        chatInfoList.sort(Comparator.comparing(ChatListResponse::createdAt).reversed());
-        return chatInfoList;
+        if (chatListResponseList.size() == 0) {
+            return chatListResponseList;
+        }
+        chatListResponseList.sort(Comparator.comparing(ChatListResponse::createdAt).reversed());
+        return chatListResponseList;
     }
+
+    private static JPQLQuery<Boolean> getLastSellerMessageIsRead() {
+        return JPAExpressions.select(sellerChat.isRead)
+                .from(sellerChat)
+                .where(sellerChat.chatRoom.chatRoomId.eq(chatRoom.chatRoomId))
+                .orderBy(sellerChat.createdAt.desc())
+                .limit(1);
+    }
+
+    private static JPQLQuery<LocalDateTime> getLastSellerMessageCreatedAt() {
+        return JPAExpressions.select(sellerChat.createdAt)
+                .from(sellerChat)
+                .where(sellerChat.chatRoom.chatRoomId.eq(chatRoom.chatRoomId))
+                .orderBy(sellerChat.createdAt.desc())
+                .limit(1);
+    }
+
+    private static JPQLQuery<String> getLastSellerMessage() {
+        return JPAExpressions.select(sellerChat.message)
+                .from(sellerChat)
+                .where(sellerChat.chatRoom.chatRoomId.eq(chatRoom.chatRoomId))
+                .orderBy(sellerChat.createdAt.desc())
+                .limit(1);
+    }
+
+    private static JPQLQuery<String> getFirstUsedBookImageUrl() {
+        return JPAExpressions.select(bookImage.imageUrl)
+                .from(bookImage)
+                .where(bookImage.usedBook.id.eq(usedBook.id))
+                .orderBy(bookImage.id.asc())
+                .limit(1);
+    }
+
+    private static JPQLQuery<Boolean> getLastBuyerMessageIsRead() {
+        return JPAExpressions.select(buyerChat.isRead)
+                .from(buyerChat)
+                .where(buyerChat.chatRoom.chatRoomId.eq(chatRoom.chatRoomId))
+                .orderBy(buyerChat.createdAt.desc())
+                .limit(1);
+    }
+
+    private static JPQLQuery<LocalDateTime> getLastBuyerMessageCreatedAt() {
+        return JPAExpressions.select(buyerChat.createdAt)
+                .from(buyerChat)
+                .where(buyerChat.chatRoom.chatRoomId.eq(chatRoom.chatRoomId))
+                .orderBy(buyerChat.createdAt.desc())
+                .limit(1);
+    }
+
+    private static JPQLQuery<String> getLastBuyerMessage() {
+        return JPAExpressions.select(buyerChat.message)
+                .from(buyerChat)
+                .where(buyerChat.chatRoom.chatRoomId.eq(chatRoom.chatRoomId))
+                .orderBy(buyerChat.createdAt.desc())
+                .limit(1);
+    }
+
 }

--- a/src/main/java/team/dankookie/server4983/chat/repository/SellerChatRepository.java
+++ b/src/main/java/team/dankookie/server4983/chat/repository/SellerChatRepository.java
@@ -1,0 +1,7 @@
+package team.dankookie.server4983.chat.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team.dankookie.server4983.chat.domain.SellerChat;
+
+public interface SellerChatRepository extends JpaRepository<SellerChat, Long> {
+}

--- a/src/main/java/team/dankookie/server4983/chat/service/ChatService.java
+++ b/src/main/java/team/dankookie/server4983/chat/service/ChatService.java
@@ -2,22 +2,23 @@ package team.dankookie.server4983.chat.service;
 
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import team.dankookie.server4983.book.constant.BookStatus;
-import team.dankookie.server4983.book.constant.College;
 import team.dankookie.server4983.book.constant.Department;
 import team.dankookie.server4983.book.domain.UsedBook;
 import team.dankookie.server4983.book.repository.usedBook.UsedBookRepository;
 import team.dankookie.server4983.chat.domain.BuyerChat;
 import team.dankookie.server4983.chat.domain.ChatRoom;
 import team.dankookie.server4983.chat.domain.SellerChat;
+import team.dankookie.server4983.chat.dto.ChatListResponse;
 import team.dankookie.server4983.chat.dto.ChatRequest;
 import team.dankookie.server4983.chat.dto.ChatRoomRequest;
+import team.dankookie.server4983.chat.dto.ChatRoomResponse;
 import team.dankookie.server4983.chat.exception.ChatException;
 import team.dankookie.server4983.chat.handler.ChatLogicHandler;
 import team.dankookie.server4983.chat.repository.ChatRoomRepository;
+import team.dankookie.server4983.jwt.constants.TokenSecretKey;
+import team.dankookie.server4983.jwt.dto.AccessToken;
 import team.dankookie.server4983.jwt.util.JwtTokenUtils;
 import team.dankookie.server4983.member.constant.AccountBank;
 import team.dankookie.server4983.member.domain.Member;
@@ -25,8 +26,8 @@ import team.dankookie.server4983.member.repository.MemberRepository;
 import team.dankookie.server4983.member.service.MemberService;
 
 import javax.security.auth.login.AccountException;
-import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 import static team.dankookie.server4983.chat.domain.ChatRoom.buildChatRoom;
 
@@ -54,7 +55,7 @@ public class ChatService {
     @Transactional
     public ChatRoomResponse createChatRoom(ChatRoomRequest chatRoomRequest , HttpServletRequest request) throws AccountException {
         String token = request.getHeader("Authorization").substring(7);
-        String userName = jwtTokenUtils.getNickname(token , key);
+        String userName = jwtTokenUtils.getNickname(token , tokenSecretKey.getSecretKey());
 
         UsedBook usedBook = usedBookRepository.findById(chatRoomRequest.getSalesPost())
                 .orElseThrow(() -> new ChatException("거래 글을 찾을 수 없습니다."));
@@ -77,7 +78,7 @@ public class ChatService {
 
     public ChatRoomResponse getChatRoom(long chatRoom , HttpServletRequest request) {
         String token = request.getHeader("Authorization").substring(7);
-        String userName = jwtTokenUtils.getNickname(token , key);
+        String userName = jwtTokenUtils.getNickname(token , tokenSecretKey.getSecretKey());
 
         ChatRoom result = chatRoomRepository.findById(chatRoom)
                 .orElseThrow(() -> new ChatException("존재하지 않는 채팅방 입니다."));

--- a/src/test/java/team/dankookie/server4983/chat/controller/ChatListControllerTest.java
+++ b/src/test/java/team/dankookie/server4983/chat/controller/ChatListControllerTest.java
@@ -1,0 +1,66 @@
+package team.dankookie.server4983.chat.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.web.servlet.ResultActions;
+import team.dankookie.server4983.chat.dto.ChatListResponse;
+import team.dankookie.server4983.chat.service.ChatService;
+import team.dankookie.server4983.common.BaseControllerTest;
+import team.dankookie.server4983.jwt.constants.TokenDuration;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class ChatListControllerTest extends BaseControllerTest {
+
+    @MockBean
+    ChatService chatService;
+
+
+    @Test
+    void accessToken으로_유저의_채팅_리스트를_리턴한다() throws Exception {
+        //given
+        ChatListResponse chatListResponse1 = ChatListResponse.of(1L, "사회과학통계방법", "안녕하세요", LocalDateTime.of(2023,9,22,12,30,12), false, "imageUrl");
+        ChatListResponse chatListResponse2 = ChatListResponse.of(2L, "컴퓨터공학개론", "테스트입니다.", LocalDateTime.of(2023,5,10,12,30,12), true, "imageUrl");
+
+        String accessToken = jwtTokenUtils.generateJwtToken("nickname", tokenSecretKey.getSecretKey(), TokenDuration.ACCESS_TOKEN_DURATION.getDuration());
+
+        when(chatService.getChatListWithAccessToken(any()))
+                .thenReturn(List.of(chatListResponse1, chatListResponse2));
+        //when
+        ResultActions resultActions = mockMvc.perform(get(API + "/chat/list")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andDo(print());
+
+        //then
+        resultActions.andExpect(status().isOk())
+                .andDo(
+                        document("chat-list/success",
+                                requestHeaders(
+                                        headerWithName(HttpHeaders.AUTHORIZATION).description("accessToken")
+                                ),
+                                responseFields(
+                                        fieldWithPath("[].chatRoomId").description("채팅방 아이디"),
+                                        fieldWithPath("[].usedBookName").description("채팅방 거래 책 이름"),
+                                        fieldWithPath("[].message").description("채팅방의 마지막 메시지"),
+                                        fieldWithPath("[].createdAt").description("채팅방의 마지막 메시지 시간"),
+                                        fieldWithPath("[].isRead").description("채팅방의 읽음 여부"),
+                                        fieldWithPath("[].imageUrl").description("채팅방의 이미지 url")
+                                )
+                        )
+                );
+    }
+
+}

--- a/src/test/java/team/dankookie/server4983/chat/repository/ChatRoomRepositoryTest.java
+++ b/src/test/java/team/dankookie/server4983/chat/repository/ChatRoomRepositoryTest.java
@@ -1,0 +1,63 @@
+package team.dankookie.server4983.chat.repository;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import team.dankookie.server4983.book.constant.BookStatus;
+import team.dankookie.server4983.book.constant.College;
+import team.dankookie.server4983.book.constant.Department;
+import team.dankookie.server4983.book.domain.UsedBook;
+import team.dankookie.server4983.book.repository.usedBook.UsedBookRepository;
+import team.dankookie.server4983.common.BaseRepositoryTest;
+import team.dankookie.server4983.member.domain.Member;
+import team.dankookie.server4983.member.fixture.MemberFixture;
+import team.dankookie.server4983.member.repository.MemberRepository;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ChatRoomRepositoryTest extends BaseRepositoryTest {
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    UsedBookRepository usedBookRepository;
+
+    @Autowired
+    ChatRoomRepository chatRoomRepository;
+
+    @Test
+    void 유저의_채팅_리스트를_리턴한다() {
+        //given
+        String nickname = "testNickname";
+        Member member = MemberFixture.createMemberByNickname(nickname);
+        Member otherMember = MemberFixture.createMember();
+        memberRepository.save(member);
+        memberRepository.save(otherMember);
+
+        UsedBook usedBook1 = UsedBook.builder()
+                .bookStatus(BookStatus.SALE)
+                .name("사회과학통계방법")
+                .buyerMember(otherMember)
+                .sellerMember(member)
+                .build();
+        usedBookRepository.save(usedBook1);
+
+        UsedBook usedBook2 = UsedBook.builder()
+                .bookStatus(BookStatus.SALE)
+                .name("사회과학통계방법")
+                .buyerMember(member)
+                .sellerMember(otherMember)
+                .build();
+        usedBookRepository.save(usedBook2);
+
+
+        //when
+        chatRoomRepository.findByChatroomWithNickname(nickname);
+
+        //then
+        
+    }
+
+}

--- a/src/test/java/team/dankookie/server4983/chat/repository/ChatRoomRepositoryTest.java
+++ b/src/test/java/team/dankookie/server4983/chat/repository/ChatRoomRepositoryTest.java
@@ -3,18 +3,22 @@ package team.dankookie.server4983.chat.repository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import team.dankookie.server4983.book.constant.BookStatus;
-import team.dankookie.server4983.book.constant.College;
-import team.dankookie.server4983.book.constant.Department;
 import team.dankookie.server4983.book.domain.UsedBook;
 import team.dankookie.server4983.book.repository.usedBook.UsedBookRepository;
+import team.dankookie.server4983.chat.constant.ContentType;
+import team.dankookie.server4983.chat.domain.BuyerChat;
+import team.dankookie.server4983.chat.domain.ChatRoom;
+import team.dankookie.server4983.chat.domain.SellerChat;
+import team.dankookie.server4983.chat.dto.ChatListResponse;
 import team.dankookie.server4983.common.BaseRepositoryTest;
 import team.dankookie.server4983.member.domain.Member;
 import team.dankookie.server4983.member.fixture.MemberFixture;
 import team.dankookie.server4983.member.repository.MemberRepository;
 
 import java.time.LocalDate;
+import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class ChatRoomRepositoryTest extends BaseRepositoryTest {
 
@@ -26,6 +30,12 @@ class ChatRoomRepositoryTest extends BaseRepositoryTest {
 
     @Autowired
     ChatRoomRepository chatRoomRepository;
+
+    @Autowired
+    BuyerChatRepository buyerChatRepository;
+
+    @Autowired
+    SellerChatRepository sellerChatRepository;
 
     @Test
     void 유저의_채팅_리스트를_리턴한다() {
@@ -41,6 +51,8 @@ class ChatRoomRepositoryTest extends BaseRepositoryTest {
                 .name("사회과학통계방법")
                 .buyerMember(otherMember)
                 .sellerMember(member)
+                .price(1000)
+                .tradeAvailableDate(LocalDate.now())
                 .build();
         usedBookRepository.save(usedBook1);
 
@@ -49,15 +61,24 @@ class ChatRoomRepositoryTest extends BaseRepositoryTest {
                 .name("사회과학통계방법")
                 .buyerMember(member)
                 .sellerMember(otherMember)
+                .price(1000)
+                .tradeAvailableDate(LocalDate.now())
                 .build();
         usedBookRepository.save(usedBook2);
 
 
+        ChatRoom chatRoom = ChatRoom.buildChatRoom(member, otherMember, usedBook1);
+        chatRoomRepository.save(chatRoom);
+        BuyerChat buyerChat = BuyerChat.buildBuyerChat("test", ContentType.BOOK_PURCHASE_START, chatRoom);
+        buyerChatRepository.save(buyerChat);
+        SellerChat sellerChat = SellerChat.buildSellerChat("test", ContentType.BOOK_PURCHASE_START, chatRoom);
+        sellerChatRepository.save(sellerChat);
+
         //when
-        chatRoomRepository.findByChatroomWithNickname(nickname);
+        List<ChatListResponse> chatListResponseList = chatRoomRepository.findByChatroomWithNickname(nickname);
 
         //then
-        
+        assertThat(chatListResponseList).hasSize(1);
     }
 
 }


### PR DESCRIPTION
## ✔ 지라 이슈 번호
DAN-28

## 📒 작업 내용
- 유저가 참가한 모든 채팅 리스트를 반환하는 api 구현

## 📢 리뷰어에게 하고 싶은 말
ex) 어디어디를 중점적으로 봐주세요 ...


## 📌 PR 전 체크 사항
- [x] base 브랜치가 **develop** 또는 **main** 브랜치로 되어있나요?
- [x] PR title에 PR Type을 표시해 두었나요? (feat:, fix:, refact: ...)
- [x] test가 모두 통과 되었나요? 