### PR TITLE
feat: 마이페이지 프로필 수정 클릭시 기존 데이터 가져오는 api 구현

### DIFF
--- a/src/docs/asciidoc/member.adoc
+++ b/src/docs/asciidoc/member.adoc
@@ -288,8 +288,20 @@ include::{snippets}/my-pages/image/delete/success/http-request.adoc[]
 ==== PathParameters
 include::{snippets}/my-pages/image/delete/success/path-parameters.adoc[]
 
-==== requestHeaders
+==== RequestHeaders
 include::{snippets}/my-pages/image/delete/success/request-headers.adoc[]
 
 ==== Response
 include::{snippets}/my-pages/image/delete/success/http-response.adoc[]
+
+=== 마이페이지 프로필 수정시 멤버의 데이터를 가져온다
+
+==== Request
+include::{snippets}/my-pages/member/modifyInfo/success/http-request.adoc[]
+
+==== RequestHeaders
+include::{snippets}/my-pages/member/modifyInfo/success/request-headers.adoc[]
+
+==== Response
+include::{snippets}/my-pages/member/modifyInfo/success/http-response.adoc[]
+include::{snippets}/my-pages/member/modifyInfo/success/response-fields.adoc[]

--- a/src/main/java/team/dankookie/server4983/member/controller/MemberMyPageController.java
+++ b/src/main/java/team/dankookie/server4983/member/controller/MemberMyPageController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import team.dankookie.server4983.jwt.dto.AccessToken;
+import team.dankookie.server4983.member.dto.MemberMyPageModifyResponse;
 import team.dankookie.server4983.member.dto.MemberMyPageResponse;
 import team.dankookie.server4983.member.service.MemberService;
 
@@ -21,6 +22,13 @@ public class MemberMyPageController {
   public ResponseEntity<MemberMyPageResponse> getMemberInfo(AccessToken accessToken) {
     MemberMyPageResponse response = memberService.getMyPageMemberInfo(
         accessToken.nickname());
+    return ResponseEntity.ok(response);
+  }
+
+  @GetMapping("/modify")
+  public ResponseEntity<MemberMyPageModifyResponse> getMemberModifyInfo(AccessToken accessToken){
+    MemberMyPageModifyResponse response = memberService.getMyPageMemberModifyInfo(
+            accessToken.nickname());
     return ResponseEntity.ok(response);
   }
 

--- a/src/main/java/team/dankookie/server4983/member/dto/MemberMyPageModifyResponse.java
+++ b/src/main/java/team/dankookie/server4983/member/dto/MemberMyPageModifyResponse.java
@@ -1,0 +1,15 @@
+package team.dankookie.server4983.member.dto;
+
+import team.dankookie.server4983.member.constant.AccountBank;
+
+public record MemberMyPageModifyResponse(
+        String imageUrl,
+        String nickname,
+        AccountBank accountBank,
+        String accountNumber,
+        String phoneNumber
+) {
+    public static MemberMyPageModifyResponse of(String imageUrl, String nickname, AccountBank accountBank, String accountNumber, String phoneNumber) {
+        return new MemberMyPageModifyResponse(imageUrl, nickname, accountBank, accountNumber, phoneNumber);
+    }
+}

--- a/src/main/java/team/dankookie/server4983/member/service/MemberService.java
+++ b/src/main/java/team/dankookie/server4983/member/service/MemberService.java
@@ -175,5 +175,10 @@ public class MemberService {
         uploadService.deleteFile(image);
         return true;
     }
+
+    public MemberMyPageModifyResponse getMyPageMemberModifyInfo(String nickname) {
+        Member member = findMemberByNickname(nickname);
+        return MemberMyPageModifyResponse.of(member.getImageUrl(), member.getNickname(), member.getAccountBank(), member.getAccountNumber(), member.getPhoneNumber());
+    }
 }
 

--- a/src/test/java/team/dankookie/server4983/member/controller/MemberMyPageControllerTest.java
+++ b/src/test/java/team/dankookie/server4983/member/controller/MemberMyPageControllerTest.java
@@ -1,0 +1,58 @@
+package team.dankookie.server4983.member.controller;
+
+import org.apache.http.HttpHeaders;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.ResultActions;
+import team.dankookie.server4983.common.BaseControllerTest;
+import team.dankookie.server4983.jwt.constants.TokenDuration;
+import team.dankookie.server4983.member.constant.AccountBank;
+import team.dankookie.server4983.member.domain.Member;
+import team.dankookie.server4983.member.dto.MemberMyPageModifyResponse;
+import team.dankookie.server4983.member.service.MemberService;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class MemberMyPageControllerTest extends BaseControllerTest {
+
+    @MockBean
+    MemberService memberService;
+    @Test
+    void 마이페이지_수정시_멤버의_데이터를_가져온다() throws Exception {
+        //given
+        String accessToken = jwtTokenUtils.generateJwtToken("nickname",  TokenDuration.ACCESS_TOKEN_DURATION.getDuration());
+        Member findMember = Member.builder().nickname("testNickname").build();
+        MemberMyPageModifyResponse response = MemberMyPageModifyResponse.of("test.png", findMember.getNickname(), AccountBank.KB, "938002-00-613983", "010-8766-5450");
+        when(memberService.getMyPageMemberModifyInfo(anyString())).thenReturn(response);
+        //when
+        ResultActions resultActions = mockMvc.perform(get(API + "/my-pages/member/modify")
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+        ).andDo(print());
+        //then
+        resultActions.andExpect(status().isOk())
+                .andDo(document("my-pages/member/modifyInfo/success",
+                        requestHeaders(
+                                headerWithName(org.springframework.http.HttpHeaders.AUTHORIZATION).description("accessToken")
+                        ),
+                        responseFields(
+                                fieldWithPath("imageUrl").description("프로필 이미지 Url"),
+                                fieldWithPath("nickname").description("회원 닉네임"),
+                                fieldWithPath("accountBank").description("은행명"),
+                                fieldWithPath("accountNumber").description("계좌번호"),
+                                fieldWithPath("phoneNumber").description("전화번호")
+                        )
+                ));
+    }
+
+}


### PR DESCRIPTION
## ✔ 지라 이슈 번호
DAN-121

## 📒 작업 내용
feat: 마이페이지 프로필 수정 클릭시 기존 데이터 가져오는 api 구현

## 📢 리뷰어에게 하고 싶은 말
ex) 어디어디를 중점적으로 봐주세요 ...


## 📌 PR 전 체크 사항
- [x] base 브랜치가 **develop** 또는 **main** 브랜치로 되어있나요?
- [x] PR title에 PR Type을 표시해 두었나요? (feat:, fix:, refact: ...)
- [x] test가 모두 통과 되었나요? 